### PR TITLE
Update deprecated-images.yml

### DIFF
--- a/articles/virtual-machines/deprecated-images.yml
+++ b/articles/virtual-machines/deprecated-images.yml
@@ -63,7 +63,7 @@ sections:
           ```
           
           
-          To find the scale set running on any retired image, specify the retired image as follows and run the query in Azure Resource Graph replacing the values below with your image details as follows:
+          - To find the scale set running on any retired image, specify the retired image as follows and run the query in Azure Resource Graph replacing the values below with your image details as follows:
           
           ```
           resources 
@@ -75,7 +75,19 @@ sections:
           |project name, subscriptionId, resourceGroup, ImagePublisher=properties.virtualMachineProfile.storageProfile.imageReference.publisher,ImageOffer=properties.virtualMachineProfile.storageProfile.imageReference.offer,imageSku=properties.virtualMachineProfile.storageProfile.imageReference.sku, imageVersion=properties.virtualMachineProfile.storageProfile.imageReference.version
           ```
           
+
+          - To get a list of both Azure VMs and scale sets, along with the images they are running and whether those images are deprecated or scheduled for deprecation, run the query in Azure Resource Graph as follows:
           
+          ```
+          resources
+          | where type in ("microsoft.compute/virtualmachines", "microsoft.compute/virtualmachinescalesets")
+          | project vmName = name, resourceGroup, location, vmId = id, imagePublisher = tostring(properties.storageProfile.imageReference.publisher), imageOffer = tostring(properties.storageProfile.imageReference.offer), imageSku = tostring(properties.storageProfile.imageReference.sku), imageVersion = tostring(properties.storageProfile.imageReference.version)
+          | join kind=leftouter (
+          resources
+          | where type == "microsoft.compute/images"
+          | project imagePublisher = tostring(properties.storageProfile.imageReference.publisher), imageOffer = tostring(properties.storageProfile.imageReference.offer), imageSku = tostring(properties.storageProfile.imageReference.sku), imageVersion = tostring(properties.storageProfile.imageReference.version), isDeprecated = properties.storageProfile.imageReference.isDeprecated, deprecationDate = properties.storageProfile.imageReference.deprecationDate
+          ) on imagePublisher, imageOffer, imageSku, imageVersion
+          | project vmName, resourceGroup, location, vmId, imagePublisher, imageOffer, imageSku, imageVersion, isDeprecated, deprecationDate
           
           **Using Azure CLI:**
 

--- a/articles/virtual-machines/deprecated-images.yml
+++ b/articles/virtual-machines/deprecated-images.yml
@@ -88,7 +88,8 @@ sections:
           | project imagePublisher = tostring(properties.storageProfile.imageReference.publisher), imageOffer = tostring(properties.storageProfile.imageReference.offer), imageSku = tostring(properties.storageProfile.imageReference.sku), imageVersion = tostring(properties.storageProfile.imageReference.version), isDeprecated = properties.storageProfile.imageReference.isDeprecated, deprecationDate = properties.storageProfile.imageReference.deprecationDate
           ) on imagePublisher, imageOffer, imageSku, imageVersion
           | project vmName, resourceGroup, location, vmId, imagePublisher, imageOffer, imageSku, imageVersion, isDeprecated, deprecationDate
-          
+          ```
+           
           **Using Azure CLI:**
 
 


### PR DESCRIPTION
Usually end users create SRs to get the list of all VMs/VMSS scheduled for the deprecation or deprecated regardless of what exactly images are being utilized in their environment. 
As an example, cx may have >100 VMs on different images and they need to know which exactly and where stands right now.
ARG request what we share in our public tutorial [Deprecated images FAQ](https://learn.microsoft.com/en-us/azure/virtual-machines/deprecated-images#how-can-i-identify-the-virtual-machines-and-virtual-machine-scale-sets-in-my-subscription-that-are-running-on-images-that-are-scheduled-for-deprecation) requires cx to know which exactly image is scheduled for deprecation to find the list of all VMs/VMSS which is utilizing this image. 
That is not really helpful, time consuming and painful
We need query which would provide list of all VMs and their depreciation status in the cx subscription.

Workitem: https://msazure.visualstudio.com/One/_workitems/edit/29410175