### PR TITLE
Convert scale sets with Azure CLI topic to exec doc

### DIFF
--- a/articles/virtual-machine-scale-sets/quick-create-cli.md
+++ b/articles/virtual-machine-scale-sets/quick-create-cli.md
@@ -4,10 +4,10 @@ description: Get started with your deployments by learning how to quickly create
 author: ju-shim
 ms.author: jushiman
 ms.topic: quickstart
-ms.service: azure-virtual-machine-scale-sets
+ms.service: azure-virtual-machine-scale-sets, 
 ms.date: 06/14/2024
 ms.reviewer: mimckitt
-ms.custom: mimckitt, devx-track-azurecli, mode-api
+ms.custom: mimckitt, devx-track-azurecli, mode-api, innovation-engine
 ---
 
 # Quickstart: Create a Virtual Machine Scale Set with the Azure CLI
@@ -35,16 +35,19 @@ https://techcommunity.microsoft.com/t5/azure-compute-blog/breaking-change-for-vm
 Before you can create a scale set, create a resource group with [az group create](/cli/azure/group). The following example creates a resource group named *myResourceGroup* in the *eastus* location:
 
 ```azurecli-interactive
-az group create --name myResourceGroup --location eastus
+export RANDOM_ID=$(openssl rand -hex 3)
+export MY_RESOURCE_GROUP_NAME="myResourceGroup$RANDOM_ID"
+az group create --name $MY_RESOURCE_GROUP_NAME --location eastus
 ```
 
 Now create a Virtual Machine Scale Set with [az vmss create](/cli/azure/vmss). The following example creates a scale set named *myScaleSet* that is set to automatically update as changes are applied, and generates SSH keys if they do not exist in *~/.ssh/id_rsa*. These SSH keys are used if you need to log in to the VM instances. To use an existing set of SSH keys, instead use the `--ssh-key-value` parameter and specify the location of your keys.
 
 ```azurecli-interactive
+export MY_SCALE_SET_NAME="myScaleSet$RANDOM_ID"
 az vmss create \
-  --resource-group myResourceGroup \
-  --name myScaleSet \
-  --image <SKU image> \
+  --resource-group $MY_RESOURCE_GROUP_NAME \
+  --name $MY_SCALE_SET_NAME \
+  --image UbuntuLTS \
   --upgrade-policy-mode automatic \
   --admin-username azureuser \
   --generate-ssh-keys
@@ -63,8 +66,8 @@ az vmss extension set \
   --publisher Microsoft.Azure.Extensions \
   --version 2.0 \
   --name CustomScript \
-  --resource-group myResourceGroup \
-  --vmss-name myScaleSet \
+  --resource-group $MY_RESOURCE_GROUP_NAME \
+  --vmss-name $MY_SCALE_SET_NAME \
   --settings '{"fileUris":["https://raw.githubusercontent.com/Azure-Samples/compute-automation-configurations/master/automate_nginx.sh"],"commandToExecute":"./automate_nginx.sh"}'
 ```
 
@@ -73,9 +76,10 @@ az vmss extension set \
 When the scale set was created, an Azure load balancer was automatically deployed. The load balancer distributes traffic to the VM instances in the scale set. To allow traffic to reach the sample web application, create a load balancer rule with [az network lb rule create](/cli/azure/network/lb/rule). The following example creates a rule named *myLoadBalancerRuleWeb*:
 
 ```azurecli-interactive
+export MY_LOAD_BALANCER_RULE_NAME="myLoadBalancerRuleWeb$RANDOM_ID"
 az network lb rule create \
-  --resource-group myResourceGroup \
-  --name myLoadBalancerRuleWeb \
+  --resource-group $MY_RESOURCE_GROUP_NAME \
+  --name $MY_LOAD_BALANCER_RULE_NAME \
   --lb-name myScaleSetLB \
   --backend-pool-name myScaleSetLBBEPool \
   --backend-port 80 \
@@ -90,7 +94,7 @@ To see your scale set in action, access the sample web application in a web brow
 
 ```azurecli-interactive
 az network public-ip show \
-  --resource-group myResourceGroup \
+  --resource-group $MY_RESOURCE_GROUP_NAME \
   --name myScaleSetLBPublicIP \
   --query '[ipAddress]' \
   --output tsv

--- a/articles/virtual-machine-scale-sets/quick-create-cli.md
+++ b/articles/virtual-machine-scale-sets/quick-create-cli.md
@@ -47,7 +47,7 @@ export MY_SCALE_SET_NAME="myScaleSet$RANDOM_ID"
 az vmss create \
   --resource-group $MY_RESOURCE_GROUP_NAME \
   --name $MY_SCALE_SET_NAME \
-  --image UbuntuLTS \
+  --image Debian11 \
   --upgrade-policy-mode automatic \
   --admin-username azureuser \
   --generate-ssh-keys

--- a/articles/virtual-machine-scale-sets/quick-create-cli.md
+++ b/articles/virtual-machine-scale-sets/quick-create-cli.md
@@ -74,7 +74,7 @@ az vmss create \
 It takes a few minutes to create and configure all the scale set resources and VMs.
 
 <!-- expected_similarity=0.3 -->
-<!--```json
+```json
 {
   "vmss": {
     "doNotRunExtensionsOnOverprovisionedVMs": false,
@@ -177,8 +177,7 @@ It takes a few minutes to create and configure all the scale set resources and V
     }
   }
 }
-```-->
-
+```
 
 ## Deploy sample application
 To test your scale set, install a basic web application. The Azure Custom Script Extension is used to download and run a script that installs an application on the VM instances. This extension is useful for post deployment configuration, software installation, or any other configuration / management task. For more information, see the [Custom Script Extension overview](../virtual-machines/extensions/custom-script-linux.md).
@@ -197,7 +196,7 @@ az vmss extension set \
 
 Results:
 <!-- expected_similarity=0.3 -->
-<!--```json 
+```json
 {
   "additionalCapabilities": null,
   "automaticRepairsPolicy": null,
@@ -396,7 +395,7 @@ Results:
   "zoneBalance": null,
   "zones": null
 }
-```-->
+```
 
 ## Allow traffic to port 80 
 To allow traffic to flow through the load balancer to the virtual machines the default network security group needs to be updated. 

--- a/articles/virtual-machine-scale-sets/quick-create-cli.md
+++ b/articles/virtual-machine-scale-sets/quick-create-cli.md
@@ -46,7 +46,7 @@ Now create a Virtual Machine Scale Set with [az vmss create](/cli/azure/vmss). T
 export MY_SCALE_SET_NAME="myScaleSet$RANDOM_ID"
 az vmss create \
   --resource-group $MY_RESOURCE_GROUP_NAME \
-  --name $MY_SCALE_SET_NAME \
+  --name myScaleSet \
   --image Debian11 \
   --upgrade-policy-mode automatic \
   --admin-username azureuser \
@@ -67,7 +67,7 @@ az vmss extension set \
   --version 2.0 \
   --name CustomScript \
   --resource-group $MY_RESOURCE_GROUP_NAME \
-  --vmss-name $MY_SCALE_SET_NAME \
+  --vmss-name myScaleSet \
   --settings '{"fileUris":["https://raw.githubusercontent.com/Azure-Samples/compute-automation-configurations/master/automate_nginx.sh"],"commandToExecute":"./automate_nginx.sh"}'
 ```
 
@@ -76,10 +76,9 @@ az vmss extension set \
 When the scale set was created, an Azure load balancer was automatically deployed. The load balancer distributes traffic to the VM instances in the scale set. To allow traffic to reach the sample web application, create a load balancer rule with [az network lb rule create](/cli/azure/network/lb/rule). The following example creates a rule named *myLoadBalancerRuleWeb*:
 
 ```azurecli-interactive
-export MY_LOAD_BALANCER_RULE_NAME="myLoadBalancerRuleWeb$RANDOM_ID"
 az network lb rule create \
   --resource-group $MY_RESOURCE_GROUP_NAME \
-  --name $MY_LOAD_BALANCER_RULE_NAME \
+  --name myLoadBalancerRuleWeb \
   --lb-name myScaleSetLB \
   --backend-pool-name myScaleSetLBBEPool \
   --backend-port 80 \
@@ -87,7 +86,6 @@ az network lb rule create \
   --frontend-port 80 \
   --protocol tcp
 ```
-
 
 ## Test your scale set
 To see your scale set in action, access the sample web application in a web browser. Obtain the public IP address of your load balancer with [az network public-ip show](/cli/azure/network/public-ip). The following example obtains the IP address for *myScaleSetLBPublicIP* created as part of the scale set:
@@ -107,11 +105,6 @@ Enter the public IP address of the load balancer in to a web browser. The load b
 
 ## Clean up resources
 When no longer needed, you can use [az group delete](/cli/azure/group) to remove the resource group, scale set, and all related resources as follows. The `--no-wait` parameter returns control to the prompt without waiting for the operation to complete. The `--yes` parameter confirms that you wish to delete the resources without an additional prompt to do so.
-
-```azurecli-interactive
-az group delete --name myResourceGroup --yes --no-wait
-```
-
 
 ## Next steps
 In this quickstart, you created a basic scale set and used the Custom Script Extension to install a basic NGINX web server on the VM instances. To learn more, continue to the tutorial for how to create and manage Azure Virtual Machine Scale Sets.

--- a/articles/virtual-machine-scale-sets/quick-create-cli.md
+++ b/articles/virtual-machine-scale-sets/quick-create-cli.md
@@ -4,7 +4,7 @@ description: Get started with your deployments by learning how to quickly create
 author: ju-shim
 ms.author: jushiman
 ms.topic: quickstart
-ms.service: azure-virtual-machine-scale-sets, 
+ms.service: azure-virtual-machine-scale-sets 
 ms.date: 06/14/2024
 ms.reviewer: mimckitt
 ms.custom: mimckitt, devx-track-azurecli, mode-api, innovation-engine

--- a/articles/virtual-machine-scale-sets/quick-create-cli.md
+++ b/articles/virtual-machine-scale-sets/quick-create-cli.md
@@ -72,19 +72,11 @@ az vmss extension set \
 ```
 
 
-## Allow traffic to application
-When the scale set was created, an Azure load balancer was automatically deployed. The load balancer distributes traffic to the VM instances in the scale set. To allow traffic to reach the sample web application, create a load balancer rule with [az network lb rule create](/cli/azure/network/lb/rule). The following example creates a rule named *myLoadBalancerRuleWeb*:
+## Allow traffic to port 80 
+To allow traffic to flow through the load balancer to the virtual machines the default network security group needs to be updated. 
 
 ```azurecli-interactive
-az network lb rule create \
-  --resource-group $MY_RESOURCE_GROUP_NAME \
-  --name myLoadBalancerRuleWeb \
-  --lb-name myScaleSetLB \
-  --backend-pool-name myScaleSetLBBEPool \
-  --backend-port 80 \
-  --frontend-ip-name loadBalancerFrontEnd \
-  --frontend-port 80 \
-  --protocol tcp
+az network nsg rule create --name AllowHTTP --resource-group myResourceGroup --nsg-name myScaleSetNSG --access Allow --priority 1010 --destination-port-ranges 80 
 ```
 
 ## Test your scale set

--- a/articles/virtual-machine-scale-sets/quick-create-cli.md
+++ b/articles/virtual-machine-scale-sets/quick-create-cli.md
@@ -43,11 +43,11 @@ az group create --name $MY_RESOURCE_GROUP_NAME --location eastus
 Now create a Virtual Machine Scale Set with [az vmss create](/cli/azure/vmss). The following example creates a scale set named *myScaleSet* that is set to automatically update as changes are applied, and generates SSH keys if they do not exist in *~/.ssh/id_rsa*. These SSH keys are used if you need to log in to the VM instances. To use an existing set of SSH keys, instead use the `--ssh-key-value` parameter and specify the location of your keys.
 
 ```azurecli-interactive
-export MY_SCALE_SET_NAME="myScaleSet$RANDOM_ID"
 az vmss create \
   --resource-group $MY_RESOURCE_GROUP_NAME \
   --name myScaleSet \
   --image Debian11 \
+  --orchestration-mode uniform \
   --upgrade-policy-mode automatic \
   --admin-username azureuser \
   --generate-ssh-keys

--- a/articles/virtual-machine-scale-sets/quick-create-cli.md
+++ b/articles/virtual-machine-scale-sets/quick-create-cli.md
@@ -445,7 +445,7 @@ az network public-ip show \
 
 Results:
 <!-- expected_similarity=0.3 -->
-``` 
+```output 
 17x.17x.21x.13x
 ```
 

--- a/articles/virtual-machine-scale-sets/quick-create-cli.md
+++ b/articles/virtual-machine-scale-sets/quick-create-cli.md
@@ -25,12 +25,7 @@ A Virtual Machine Scale Set allows you to deploy and manage a set of auto-scalin
 
 - This article requires version 2.0.29 or later of the Azure CLI. If using Azure Cloud Shell, the latest version is already installed.
 
-
-## Create a scale set
-
-> [!IMPORTANT]
->Starting November 2023, VM scale sets created using PowerShell and Azure CLI will default to Flexible Orchestration Mode if no orchestration mode is specified. For more information about this change and what actions you should take, go to [Breaking Change for VMSS PowerShell/CLI Customers - Microsoft Community Hub](
-https://techcommunity.microsoft.com/t5/azure-compute-blog/breaking-change-for-vmss-powershell-cli-customers/ba-p/3818295)
+## Create a resource group
 
 Before you can create a scale set, create a resource group with [az group create](/cli/azure/group). The following example creates a resource group named *myResourceGroup* in the *eastus* location:
 
@@ -39,6 +34,29 @@ export RANDOM_ID=$(openssl rand -hex 3)
 export MY_RESOURCE_GROUP_NAME="myResourceGroup$RANDOM_ID"
 az group create --name $MY_RESOURCE_GROUP_NAME --location eastus
 ```
+
+Results:
+<!-- expected_similarity=0.3 -->
+```json   
+{
+  "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroupxxxxx",
+  "location": "eastus",
+  "managedBy": null,
+  "name": "myResourceGroupxxxxx",
+  "properties": {
+    "provisioningState": "Succeeded"
+  },
+  "tags": null,
+  "type": "Microsoft.Resources/resourceGroups"
+}
+```
+
+## Create a scale set
+
+> [!IMPORTANT]
+>Starting November 2023, VM scale sets created using PowerShell and Azure CLI will default to Flexible Orchestration Mode if no orchestration mode is specified. For more information about this change and what actions you should take, go to [Breaking Change for VMSS PowerShell/CLI Customers - Microsoft Community Hub](
+https://techcommunity.microsoft.com/t5/azure-compute-blog/breaking-change-for-vmss-powershell-cli-customers/ba-p/3818295)
+
 
 Now create a Virtual Machine Scale Set with [az vmss create](/cli/azure/vmss). The following example creates a scale set named *myScaleSet* that is set to automatically update as changes are applied, and generates SSH keys if they do not exist in *~/.ssh/id_rsa*. These SSH keys are used if you need to log in to the VM instances. To use an existing set of SSH keys, instead use the `--ssh-key-value` parameter and specify the location of your keys.
 
@@ -54,6 +72,112 @@ az vmss create \
 ```
 
 It takes a few minutes to create and configure all the scale set resources and VMs.
+
+<!-- expected_similarity=0.3 -->
+```json
+{
+  "vmss": {
+    "doNotRunExtensionsOnOverprovisionedVMs": false,
+    "orchestrationMode": "Uniform",
+    "overprovision": true,
+    "platformFaultDomainCount": 5,
+    "provisioningState": "Succeeded",
+    "singlePlacementGroup": true,
+    "timeCreated": "2024-09-12T14:59:53.9329416+00:00",
+    "uniqueId": "ac6d7ee7-f69f-498d-9ce4-dd325eb0f89e",
+    "upgradePolicy": {
+      "mode": "Automatic"
+    },
+    "virtualMachineProfile": {
+      "networkProfile": {
+        "networkInterfaceConfigurations": [
+          {
+            "name": "myscaxxxxNic",
+            "properties": {
+              "disableTcpStateTracking": false,
+              "dnsSettings": {
+                "dnsServers": []
+              },
+              "enableAcceleratedNetworking": false,
+              "enableIPForwarding": false,
+              "ipConfigurations": [
+                {
+                  "name": "myscaxxxxIPConfig",
+                  "properties": {
+                    "loadBalancerBackendAddressPools": [
+                      {
+                        "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroupxxxxx/providers/Microsoft.Network/loadBalancers/myScaleSetLB/backendAddressPools/myScaleSetLBBEPool",
+                        "resourceGroup": "myResourceGroupxxxxx"
+                      }
+                    ],
+                    "privateIPAddressVersion": "IPv4",
+                    "subnet": {
+                      "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroupxxxxx/providers/Microsoft.Network/virtualNetworks/myScaleSetVNET/subnets/myScaleSetSubnet",
+                      "resourceGroup": "myResourceGroupxxxxx"
+                    }
+                  }
+                }
+              ],
+              "networkSecurityGroup": {
+                "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroupxxxxx/providers/Microsoft.Network/networkSecurityGroups/myScaleSetNSG",
+                "resourceGroup": "myResourceGroupxxxxx"
+              },
+              "primary": true
+            }
+          }
+        ]
+      },
+      "osProfile": {
+        "adminUsername": "azureuser",
+        "allowExtensionOperations": true,
+        "computerNamePrefix": "myscaxxxx",
+        "linuxConfiguration": {
+          "disablePasswordAuthentication": true,
+          "provisionVMAgent": true,
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "ssh-rsa xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+                xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+                xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                "path": "/home/azureuser/.ssh/authorized_keys"
+              }
+            ]
+          }
+        },
+        "requireGuestProvisionSignal": true,
+        "secrets": []
+      },
+      "securityProfile": {
+        "securityType": "TrustedLaunch",
+        "uefiSettings": {
+          "secureBootEnabled": true,
+          "vTpmEnabled": true
+        }
+      },
+      "storageProfile": {
+        "diskControllerType": "SCSI",
+        "imageReference": {
+          "offer": "debian-11",
+          "publisher": "Debian",
+          "sku": "11-backports-gen2",
+          "version": "latest"
+        },
+        "osDisk": {
+          "caching": "ReadWrite",
+          "createOption": "FromImage",
+          "diskSizeGB": 30,
+          "managedDisk": {
+            "storageAccountType": "Premium_LRS"
+          },
+          "osType": "Linux"
+        }
+      },
+      "timeCreated": "2024-09-12T14:59:53.9329416+00:00"
+    }
+  }
+}
+```
 
 
 ## Deploy sample application
@@ -71,6 +195,208 @@ az vmss extension set \
   --settings '{"fileUris":["https://raw.githubusercontent.com/Azure-Samples/compute-automation-configurations/master/automate_nginx.sh"],"commandToExecute":"./automate_nginx.sh"}'
 ```
 
+Results:
+<!-- expected_similarity=0.3 -->
+```json 
+{
+  "additionalCapabilities": null,
+  "automaticRepairsPolicy": null,
+  "constrainedMaximumCapacity": null,
+  "doNotRunExtensionsOnOverprovisionedVMs": false,
+  "etag": "\"3\"",
+  "extendedLocation": null,
+  "hostGroup": null,
+  "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroupxxxxx/providers/Microsoft.Compute/virtualMachineScaleSets/myScaleSet",
+  "identity": null,
+  "location": "eastus",
+  "name": "myScaleSet",
+  "orchestrationMode": "Uniform",
+  "overprovision": true,
+  "plan": null,
+  "platformFaultDomainCount": 5,
+  "priorityMixPolicy": null,
+  "provisioningState": "Succeeded",
+  "proximityPlacementGroup": null,
+  "resiliencyPolicy": null,
+  "resourceGroup": "myResourceGroupxxxxx",
+  "scaleInPolicy": null,
+  "scheduledEventsPolicy": null,
+  "singlePlacementGroup": true,
+  "sku": {
+    "capacity": 2,
+    "name": "Standard_DS1_v2",
+    "tier": "Standard"
+  },
+  "skuProfile": null,
+  "spotRestorePolicy": null,
+  "tags": {},
+  "timeCreated": "2024-09-12T14:59:53.932941+00:00",
+  "type": "Microsoft.Compute/virtualMachineScaleSets",
+  "uniqueId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx",
+  "upgradePolicy": {
+    "automaticOsUpgradePolicy": null,
+    "mode": "Automatic",
+    "rollingUpgradePolicy": null
+  },
+  "virtualMachineProfile": {
+    "applicationProfile": null,
+    "billingProfile": null,
+    "capacityReservation": null,
+    "diagnosticsProfile": null,
+    "evictionPolicy": null,
+    "extensionProfile": {
+      "extensions": [
+        {
+          "autoUpgradeMinorVersion": true,
+          "enableAutomaticUpgrade": null,
+          "forceUpdateTag": null,
+          "id": null,
+          "name": "CustomScript",
+          "protectedSettings": null,
+          "protectedSettingsFromKeyVault": null,
+          "provisionAfterExtensions": null,
+          "provisioningState": null,
+          "publisher": "Microsoft.Azure.Extensions",
+          "settings": {
+            "commandToExecute": "./automate_nginx.sh",
+            "fileUris": [
+              "https://raw.githubusercontent.com/Azure-Samples/compute-automation-configurations/master/automate_nginx.sh"
+            ]
+          },
+          "suppressFailures": null,
+          "type": null,
+          "typeHandlerVersion": "2.0",
+          "typePropertiesType": "CustomScript"
+        }
+      ],
+      "extensionsTimeBudget": null
+    },
+    "hardwareProfile": null,
+    "licenseType": null,
+    "networkProfile": {
+      "healthProbe": null,
+      "networkApiVersion": null,
+      "networkInterfaceConfigurations": [
+        {
+          "auxiliaryMode": null,
+          "auxiliarySku": null,
+          "deleteOption": null,
+          "disableTcpStateTracking": false,
+          "dnsSettings": {
+            "dnsServers": []
+          },
+          "enableAcceleratedNetworking": false,
+          "enableFpga": null,
+          "enableIpForwarding": false,
+          "ipConfigurations": [
+            {
+              "applicationGatewayBackendAddressPools": null,
+              "applicationSecurityGroups": null,
+              "loadBalancerBackendAddressPools": [
+                {
+                  "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroupxxxxx/providers/Microsoft.Network/loadBalancers/myScaleSetLB/backendAddressPools/myScaleSetLBBEPool",
+                  "resourceGroup": "myResourceGroupxxxxx"
+                }
+              ],
+              "loadBalancerInboundNatPools": null,
+              "name": "myscaxxxxIPConfig",
+              "primary": null,
+              "privateIpAddressVersion": "IPv4",
+              "publicIpAddressConfiguration": null,
+              "subnet": {
+                "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroupxxxxx/providers/Microsoft.Network/virtualNetworks/myScaleSetVNET/subnets/myScaleSetSubnet",
+                "resourceGroup": "myResourceGroupxxxxx"
+              }
+            }
+          ],
+          "name": "myscaxxxxNic",
+          "networkSecurityGroup": {
+            "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroupxxxxx/providers/Microsoft.Network/networkSecurityGroups/myScaleSetNSG",
+            "resourceGroup": "myResourceGroupxxxxx"
+          },
+          "primary": true
+        }
+      ]
+    },
+    "osProfile": {
+      "adminPassword": null,
+      "adminUsername": "azureuser",
+      "allowExtensionOperations": true,
+      "computerNamePrefix": "myscaxxxx",
+      "customData": null,
+      "linuxConfiguration": {
+        "disablePasswordAuthentication": true,
+        "enableVmAgentPlatformUpdates": null,
+        "patchSettings": null,
+        "provisionVmAgent": true,
+        "ssh": {
+          "publicKeys": [
+            {
+              "keyData": "ssh-rsa xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+                xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+                xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "path": "/home/azureuser/.ssh/authorized_keys"
+            }
+          ]
+        }
+      },
+      "requireGuestProvisionSignal": true,
+      "secrets": [],
+      "windowsConfiguration": null
+    },
+    "priority": null,
+    "scheduledEventsProfile": null,
+    "securityPostureReference": null,
+    "securityProfile": {
+      "encryptionAtHost": null,
+      "encryptionIdentity": null,
+      "proxyAgentSettings": null,
+      "securityType": "TrustedLaunch",
+      "uefiSettings": {
+        "secureBootEnabled": true,
+        "vTpmEnabled": true
+      }
+    },
+    "serviceArtifactReference": null,
+    "storageProfile": {
+      "dataDisks": null,
+      "diskControllerType": "SCSI",
+      "imageReference": {
+        "communityGalleryImageId": null,
+        "exactVersion": null,
+        "id": null,
+        "offer": "debian-11",
+        "publisher": "Debian",
+        "sharedGalleryImageId": null,
+        "sku": "11-backports-gen2",
+        "version": "latest"
+      },
+      "osDisk": {
+        "caching": "ReadWrite",
+        "createOption": "FromImage",
+        "deleteOption": null,
+        "diffDiskSettings": null,
+        "diskSizeGb": 30,
+        "image": null,
+        "managedDisk": {
+          "diskEncryptionSet": null,
+          "securityProfile": null,
+          "storageAccountType": "Premium_LRS"
+        },
+        "name": null,
+        "osType": "Linux",
+        "vhdContainers": null,
+        "writeAcceleratorEnabled": null
+      }
+    },
+    "timeCreated": "2024-09-12T15:01:22.416655+00:00",
+    "userData": null
+  },
+  "zonalPlatformFaultDomainAlignMode": null,
+  "zoneBalance": null,
+  "zones": null
+}
+```
 
 ## Allow traffic to port 80 
 To allow traffic to flow through the load balancer to the virtual machines the default network security group needs to be updated. 
@@ -85,6 +411,32 @@ az network nsg rule create \
   --destination-port-ranges 80 \
 ```
 
+Results:
+<!-- expected_similarity=0.3 -->
+```json 
+{
+  "access": "Allow",
+  "destinationAddressPrefix": "*",
+  "destinationAddressPrefixes": [],
+  "destinationPortRange": "80",
+  "destinationPortRanges": [],
+  "direction": "Inbound",
+  "etag": "W/\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\"",
+  "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroupxxxxx/providers/Microsoft.Network/networkSecurityGroups/myScaleSetNSG/securityRules/AllowHTTP",
+  "name": "AllowHTTP",
+  "priority": 1010,
+  "protocol": "*",
+  "provisioningState": "Succeeded",
+  "resourceGroup": "myResourceGroupxxxxx",
+  "sourceAddressPrefix": "*",
+  "sourceAddressPrefixes": [],
+  "sourcePortRange": "*",
+  "sourcePortRanges": [],
+  "type": "Microsoft.Network/networkSecurityGroups/securityRules"
+}
+
+```
+
 ## Test your scale set
 To see your scale set in action, access the sample web application in a web browser. Obtain the public IP address of your load balancer with [az network public-ip show](/cli/azure/network/public-ip). The following example obtains the IP address for *myScaleSetLBPublicIP* created as part of the scale set:
 
@@ -94,6 +446,12 @@ az network public-ip show \
   --name myScaleSetLBPublicIP \
   --query '[ipAddress]' \
   --output tsv
+```
+
+Results:
+<!-- expected_similarity=0.3 -->
+``` 
+17x.17x.21x.13x
 ```
 
 Enter the public IP address of the load balancer in to a web browser. The load balancer distributes traffic to one of your VM instances, as shown in the following example:

--- a/articles/virtual-machine-scale-sets/quick-create-cli.md
+++ b/articles/virtual-machine-scale-sets/quick-create-cli.md
@@ -76,7 +76,13 @@ az vmss extension set \
 To allow traffic to flow through the load balancer to the virtual machines the default network security group needs to be updated. 
 
 ```azurecli-interactive
-az network nsg rule create --name AllowHTTP --resource-group myResourceGroup --nsg-name myScaleSetNSG --access Allow --priority 1010 --destination-port-ranges 80 
+az network nsg rule create \
+  --name AllowHTTP \
+  --resource-group $MY_RESOURCE_GROUP_NAME \
+  --nsg-name myScaleSetNSG \
+  --access Allow \
+  --priority 1010 \
+  --destination-port-ranges 80 \
 ```
 
 ## Test your scale set

--- a/articles/virtual-machine-scale-sets/quick-create-cli.md
+++ b/articles/virtual-machine-scale-sets/quick-create-cli.md
@@ -394,7 +394,7 @@ Results:
 ```
 
 ## Allow traffic to port 80 
-To allow traffic to flow through the load balancer to the virtual machines the default network security group needs to be updated. 
+To allow traffic to flow through the load balancer to the virtual machines, the default network security group needs to be updated. 
 
 ```azurecli-interactive
 az network nsg rule create \

--- a/articles/virtual-machine-scale-sets/quick-create-cli.md
+++ b/articles/virtual-machine-scale-sets/quick-create-cli.md
@@ -137,9 +137,7 @@ It takes a few minutes to create and configure all the scale set resources and V
           "ssh": {
             "publicKeys": [
               {
-                "keyData": "ssh-rsa xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-                xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-                xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                "keyData": "ssh-rsa xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxXxxxx",
                 "path": "/home/azureuser/.ssh/authorized_keys"
               }
             ]
@@ -331,9 +329,7 @@ Results:
         "ssh": {
           "publicKeys": [
             {
-              "keyData": "ssh-rsa xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-                xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-                xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "keyData": "ssh-rsa xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxXxxxx",
               "path": "/home/azureuser/.ssh/authorized_keys"
             }
           ]

--- a/articles/virtual-machine-scale-sets/quick-create-cli.md
+++ b/articles/virtual-machine-scale-sets/quick-create-cli.md
@@ -74,7 +74,7 @@ az vmss create \
 It takes a few minutes to create and configure all the scale set resources and VMs.
 
 <!-- expected_similarity=0.3 -->
-```json
+<!--```json
 {
   "vmss": {
     "doNotRunExtensionsOnOverprovisionedVMs": false,
@@ -177,7 +177,7 @@ It takes a few minutes to create and configure all the scale set resources and V
     }
   }
 }
-```
+```-->
 
 
 ## Deploy sample application
@@ -197,7 +197,7 @@ az vmss extension set \
 
 Results:
 <!-- expected_similarity=0.3 -->
-```json 
+<!--```json 
 {
   "additionalCapabilities": null,
   "automaticRepairsPolicy": null,
@@ -396,7 +396,7 @@ Results:
   "zoneBalance": null,
   "zones": null
 }
-```
+```-->
 
 ## Allow traffic to port 80 
 To allow traffic to flow through the load balancer to the virtual machines the default network security group needs to be updated. 


### PR DESCRIPTION
Hi, @ju-shim!

I'm working with Naman Parikh and Carol Smith to convert a set of topics to executable documentation. 

Work item: https://dev.azure.com/msft-skilling/Content/_workitems/edit/271058

If you're not already familiar with that initiative, here's some information about it, https://github.com/MicrosoftDocs/executable-docs/blob/main/README.md, and I'm happy to set up some time to talk through my changes.

The intent is that very little content has to change to make the topic executable. But I did find a few things I needed to update to get the examples to work, and would really like your help confirming my changes are correct!

- Updated `az vmss create` to explicitly set the uniform orchestration mode. Uniform used to be the default, and the topic relies on that default. However, that default changed in Nov 2023 to flexible. 
- Changed "Allow traffic to the application" section to "Allow traffic to port 80". The original content was creating another load balancer rule. Because one is created by default, I was getting an error complaining that two rules can't have the same configuration. I found the "Allow traffic to port 80" in [this topic](https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/tutorial-install-apps-cli) and it seemed to solve my issues. 

Some other changes to support the executable experience:
- Created a section specifically for "Create a resource group" for step transparency in both the topic and the executable experience.
- Parameter changes: Used a global variable for resource group, since it's referenced in multiple code blocks. Choose a specific image to reference in the `az vmss create` so the code can execute without intervention. 
- Added result code blocks.
- Removed the code block for deleting resources, because the executable experience does that automatically. Left the prose though. 

Thanks for your review on these updates and let me know if a sync up is helpful!
