### PR TITLE
Update prepare-for-upload-vhd-image.md

### DIFF
--- a/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
+++ b/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
@@ -546,7 +546,7 @@ Use one of the methods in this section to convert and resize your virtual disk t
 
       ```powershell
       $vhd = Get-VHD -Path C:\test\MyNewVM.vhd
-      $vhd.Size % 1MB
+      $vhd.Size % 1048576
       0
       $vhd.FileSize - $vhd.Size
       512


### PR DESCRIPTION
Corrected 1 MB to 1 Mebibytes
1 Mebibytes = 1048576 byte
so
"$vhd.Size % 1048576 " is correct

1MB is inconsistent with this statement.
It also fails to upload.
-------
Disks in Azure must have a virtual size aligned to 1 MiB. If your VHD is a fraction of 1 MiB, you'll need to resize the disk to a multiple of 1 MiB. Disks that are fractions of a MiB cause errors when creating images from the uploaded VHD. To verify the size you can use the PowerShell [Get-VHD](https://github.com/MicrosoftDocs/azure-compute-docs/blob/main/powershell/module/hyper-v/get-vhd) cmdlet to show "Size", which must be a multiple of 1 MiB in Azure, and "FileSize", which will be equal to "Size" plus 512 bytes for the VHD footer.
-------