### PR TITLE
Update disk-encryption-troubleshooting.md

### DIFF
--- a/articles/virtual-machines/linux/disk-encryption-troubleshooting.md
+++ b/articles/virtual-machines/linux/disk-encryption-troubleshooting.md
@@ -38,7 +38,7 @@ This error can occur when OS disk encryption is attempted on a VM with an enviro
 
 ## Update the default kernel for Ubuntu 14.04 LTS
 
-The Ubuntu 14.04 LTS image ships with a default kernel version of 4.4. This kernel version has a known issue in which Out of Memory Killer improperly terminates the dd command during the OS encryption process. This bug has been fixed in the most recent Azure tuned Linux kernel. To avoid this error, prior to enabling encryption on the image, update to the [Azure tuned kernel 4.15] or later using the following commands:
+The Ubuntu 14.04 LTS image ships with a default kernel version of 4.4. This kernel version has a known issue in which Out of Memory Killer improperly terminates the dd command during the OS encryption process. This bug has been fixed in the most recent Azure tuned Linux kernel. To avoid this error, prior to enabling encryption on the image, update to the Azure tuned kernel 4.15 or later using the following commands:
 
 ```
 sudo apt-get update

--- a/articles/virtual-machines/linux/disk-encryption-troubleshooting.md
+++ b/articles/virtual-machines/linux/disk-encryption-troubleshooting.md
@@ -38,7 +38,7 @@ This error can occur when OS disk encryption is attempted on a VM with an enviro
 
 ## Update the default kernel for Ubuntu 14.04 LTS
 
-The Ubuntu 14.04 LTS image ships with a default kernel version of 4.4. This kernel version has a known issue in which Out of Memory Killer improperly terminates the dd command during the OS encryption process. This bug has been fixed in the most recent Azure tuned Linux kernel. To avoid this error, prior to enabling encryption on the image, update to the [Azure tuned kernel 4.15](https://packages.ubuntu.com/trusty/linux-azure) or later using the following commands:
+The Ubuntu 14.04 LTS image ships with a default kernel version of 4.4. This kernel version has a known issue in which Out of Memory Killer improperly terminates the dd command during the OS encryption process. This bug has been fixed in the most recent Azure tuned Linux kernel. To avoid this error, prior to enabling encryption on the image, update to the [Azure tuned kernel 4.15] or later using the following commands:
 
 ```
 sudo apt-get update


### PR DESCRIPTION
https://packages.ubuntu.com/trusty/linux-azure

Above hyperlink is mentioned in the document which throws error. Please check if we can update with correct one or remove it completely. Below is the line in document:

Under: 
Update the default kernel for Ubuntu 14.04 LTS:
To avoid this error, prior to enabling encryption on the image, update to the Azure tuned kernel 4.15 or later using the following commands: