### PR TITLE
Fix typo (Set-AzVMssRunCommand -> SetAzVMss*VM*RunCommand)

### DIFF
--- a/articles/virtual-machines/linux/run-command-managed.md
+++ b/articles/virtual-machines/linux/run-command-managed.md
@@ -83,7 +83,7 @@ az vm run-command show --name "myRunCommand" --vm-name "myVM" --resource-group "
 
 > [!Note]
 > Output and error fields in `instanceView` is limited to last 4KB.
-> If you'd like to access the full output and error, you have the option of forwarding the output and error data to storage append blobs using `-outputBlobUri` and `-errorBlobUri` parameters while executing Run Command using `Set-AzVMRunCommand` or `Set-AzVMssRunCommand`.
+> If you'd like to access the full output and error, you have the option of forwarding the output and error data to storage append blobs using `-outputBlobUri` and `-errorBlobUri` parameters while executing Run Command using `Set-AzVMRunCommand` or `Set-AzVMssVMRunCommand`.
 
 ### Delete RunCommand resource from the VM
 Remove the RunCommand resource previously deployed on the VM. If the script execution is still in progress, execution will be terminated. 

--- a/articles/virtual-machines/windows/run-command-managed.md
+++ b/articles/virtual-machines/windows/run-command-managed.md
@@ -81,7 +81,7 @@ az vm run-command show --name "myRunCommand" --vm-name "myVM" --resource-group "
 
 > [!Note]
 > Output and error fields in `instanceView` is limited to last 4KB.
-> If you'd like to access the full output and error, you have the option of forwarding the output and error data to storage append blobs using `-outputBlobUri` and `-errorBlobUri` parameters while executing Run Command using `Set-AzVMRunCommand` or `Set-AzVMssRunCommand`.
+> If you'd like to access the full output and error, you have the option of forwarding the output and error data to storage append blobs using `-outputBlobUri` and `-errorBlobUri` parameters while executing Run Command using `Set-AzVMRunCommand` or `Set-AzVMssVMRunCommand`.
 
 ### Delete RunCommand resource from the VM
 Remove the RunCommand resource previously deployed on the VM. If the script execution is still in progress, execution will be terminated. 


### PR DESCRIPTION
As mentioned in the title, the docs refer to a non-existent command `Set-AzVMssRunCommand`, where the way to run a command on a specific VMss instance is `Set-AzVMssVMRunCommand` (missing `VM` in the command name).