### PR TITLE
Update windows-in-place-upgrade.md

### DIFF
--- a/articles/virtual-machines/windows-in-place-upgrade.md
+++ b/articles/virtual-machines/windows-in-place-upgrade.md
@@ -182,7 +182,7 @@ To initiate the in-place upgrade the VM must be in the `Running` state. Once the
    .\setup.exe /auto upgrade /dynamicupdate disable /eula accept
    ```
 
-6. Select the correct "Upgrade to" image based on the current version and configuration of the VM using the [Windows Server upgrade matrix](/windows-server/get-started/upgrade-overview).
+1. Select the correct "Upgrade to" image based on the current version and configuration of the VM using the [Windows Server upgrade matrix](/windows-server/get-started/upgrade-overview).
 
 During the upgrade process the VM will automatically disconnect from the RDP session. After the VM is disconnected from the RDP session the progress of the upgrade can be monitored through the [screenshot functionality available in the Azure portal](/troubleshoot/azure/virtual-machines/boot-diagnostics#enable-boot-diagnostics-on-existing-virtual-machine).
 

--- a/articles/virtual-machines/windows-in-place-upgrade.md
+++ b/articles/virtual-machines/windows-in-place-upgrade.md
@@ -175,15 +175,14 @@ To initiate the in-place upgrade the VM must be in the `Running` state. Once the
    .\setup.exe /auto upgrade /dynamicupdate disable 
    ```
 
-> [!NOTE]
-> You can use /eula accept switch in the Windows Server upgrade command, to automatically accept the Microsoft Software License Terms (End User License Agreement, or EULA) during the upgrade process.
-> Using the /eula accept switch can help avoid issues where the upgrade process stalls because the EULA was not accepted manually. This switch ensures that the upgrade process can proceed smoothly without requiring user interaction to accept the license terms.
-> 
+   You can use /eula accept switch in the Windows Server upgrade command, to automatically accept the Microsoft Software License Terms (End User License Agreement,     or EULA) during the upgrade process.
+   Using the /eula accept switch can help avoid issues where the upgrade process stalls because the EULA was not accepted manually. This switch ensures that the        upgrade process can proceed smoothly without requiring user interaction to accept the license terms.
+ 
    ```powershell
-.\setup.exe /auto upgrade /dynamicupdate disable /eula accept
-```
+   .\setup.exe /auto upgrade /dynamicupdate disable /eula accept
+   ```
 
-1. Select the correct "Upgrade to" image based on the current version and configuration of the VM using the [Windows Server upgrade matrix](/windows-server/get-started/upgrade-overview).
+6. Select the correct "Upgrade to" image based on the current version and configuration of the VM using the [Windows Server upgrade matrix](/windows-server/get-started/upgrade-overview).
 
 During the upgrade process the VM will automatically disconnect from the RDP session. After the VM is disconnected from the RDP session the progress of the upgrade can be monitored through the [screenshot functionality available in the Azure portal](/troubleshoot/azure/virtual-machines/boot-diagnostics#enable-boot-diagnostics-on-existing-virtual-machine).
 

--- a/articles/virtual-machines/windows-in-place-upgrade.md
+++ b/articles/virtual-machines/windows-in-place-upgrade.md
@@ -176,7 +176,7 @@ To initiate the in-place upgrade the VM must be in the `Running` state. Once the
    ```
 
    You can use /eula accept switch in the Windows Server upgrade command to automatically accept the Microsoft Software License Terms (End User License Agreement or EULA) during the upgrade process.
-   Using the /eula accept switch can help avoid issues where the upgrade process stalls because the EULA was not accepted manually. This switch ensures that the        upgrade process can proceed smoothly without requiring user interaction to accept the license terms.
+   Using the /eula accept switch can help avoid issues where the upgrade process stalls because the EULA was not accepted manually. This switch ensures that the upgrade process can proceed smoothly without requiring user interaction to accept the license terms.
  
    ```powershell
    .\setup.exe /auto upgrade /dynamicupdate disable /eula accept

--- a/articles/virtual-machines/windows-in-place-upgrade.md
+++ b/articles/virtual-machines/windows-in-place-upgrade.md
@@ -175,6 +175,14 @@ To initiate the in-place upgrade the VM must be in the `Running` state. Once the
    .\setup.exe /auto upgrade /dynamicupdate disable 
    ```
 
+> [!NOTE]
+> You can use /eula accept switch in the Windows Server upgrade command, to automatically accept the Microsoft Software License Terms (End User License Agreement, or EULA) during the upgrade process.
+> Using the /eula accept switch can help avoid issues where the upgrade process stalls because the EULA was not accepted manually. This switch ensures that the upgrade process can proceed smoothly without requiring user interaction to accept the license terms.
+> 
+   ```powershell
+.\setup.exe /auto upgrade /dynamicupdate disable /eula accept
+```
+
 1. Select the correct "Upgrade to" image based on the current version and configuration of the VM using the [Windows Server upgrade matrix](/windows-server/get-started/upgrade-overview).
 
 During the upgrade process the VM will automatically disconnect from the RDP session. After the VM is disconnected from the RDP session the progress of the upgrade can be monitored through the [screenshot functionality available in the Azure portal](/troubleshoot/azure/virtual-machines/boot-diagnostics#enable-boot-diagnostics-on-existing-virtual-machine).

--- a/articles/virtual-machines/windows-in-place-upgrade.md
+++ b/articles/virtual-machines/windows-in-place-upgrade.md
@@ -175,7 +175,7 @@ To initiate the in-place upgrade the VM must be in the `Running` state. Once the
    .\setup.exe /auto upgrade /dynamicupdate disable 
    ```
 
-   You can use /eula accept switch in the Windows Server upgrade command, to automatically accept the Microsoft Software License Terms (End User License Agreement,     or EULA) during the upgrade process.
+   You can use /eula accept switch in the Windows Server upgrade command to automatically accept the Microsoft Software License Terms (End User License Agreement or EULA) during the upgrade process.
    Using the /eula accept switch can help avoid issues where the upgrade process stalls because the EULA was not accepted manually. This switch ensures that the        upgrade process can proceed smoothly without requiring user interaction to accept the license terms.
  
    ```powershell


### PR DESCRIPTION
You can use /eula accept switch in the Windows Server upgrade command, to automatically accept the Microsoft Software License Terms (End User License Agreement, or EULA) during the upgrade process. Using the /eula accept switch can help avoid issues where the upgrade process stalls because the EULA was not accepted manually. This switch ensures that the upgrade process can proceed smoothly without requiring user interaction to accept the license terms.