### PR TITLE
The F*sv6 VM Series is in public preview

### DIFF
--- a/articles/virtual-machines/sizes/compute-optimized/falsv6-series.md
+++ b/articles/virtual-machines/sizes/compute-optimized/falsv6-series.md
@@ -10,9 +10,13 @@ ms.author: mattmcinnes
 ms.reviewer: mattmcinnes
 ---
 
-# Falsv6 sizes series
+# Falsv6 sizes series (Preview)
 
 [!INCLUDE [falsv6-summary](./includes/falsv6-series-summary.md)]
+
+> [!NOTE]
+> - This VM series is currently in **Preview**. 
+> - See the [Preview Terms Of Use | Microsoft Azure](https://azure.microsoft.com/support/legal/preview-supplemental-terms/) for legal terms that apply to Azure features that are in beta, preview, or otherwise not yet released into general availability.
 
 ## Host specifications
 [!INCLUDE [falsv6-series-specs](./includes/falsv6-series-specs.md)]

--- a/articles/virtual-machines/sizes/compute-optimized/famsv6-series.md
+++ b/articles/virtual-machines/sizes/compute-optimized/famsv6-series.md
@@ -10,9 +10,13 @@ ms.author: mattmcinnes
 ms.reviewer: mattmcinnes
 ---
 
-# Famsv6 sizes series
+# Famsv6 sizes series (Preview)
 
 [!INCLUDE [famsv6-summary](./includes/famsv6-series-summary.md)]
+
+> [!NOTE]
+> - This VM series is currently in **Preview**. 
+> - See the [Preview Terms Of Use | Microsoft Azure](https://azure.microsoft.com/support/legal/preview-supplemental-terms/) for legal terms that apply to Azure features that are in beta, preview, or otherwise not yet released into general availability.
 
 ## Host specifications
 [!INCLUDE [famsv6-series-specs](./includes/famsv6-series-specs.md)]

--- a/articles/virtual-machines/sizes/compute-optimized/fasv6-series.md
+++ b/articles/virtual-machines/sizes/compute-optimized/fasv6-series.md
@@ -10,9 +10,13 @@ ms.author: mattmcinnes
 ms.reviewer: mattmcinnes
 ---
 
-# Fasv6 sizes series
+# Fasv6 sizes series (Preview)
 
 [!INCLUDE [fasv6-summary](./includes/fasv6-series-summary.md)]
+
+> [!NOTE]
+> - This VM series is currently in **Preview**. 
+> - See the [Preview Terms Of Use | Microsoft Azure](https://azure.microsoft.com/support/legal/preview-supplemental-terms/) for legal terms that apply to Azure features that are in beta, preview, or otherwise not yet released into general availability.
 
 ## Host specifications
 [!INCLUDE [fasv6-series-specs](./includes/fasv6-series-specs.md)]


### PR DESCRIPTION
The F*sv6 VM Series is still in public preview, and the public documentation has been updated to reflect this status. https://techcommunity.microsoft.com/blog/azurecompute/public-preview-new-amd-based-vms-with-increased-performance-azure-boost-and-nvme/3981351