### PR TITLE
Adding explicitly requirement to set context of subscription

### DIFF
--- a/articles/virtual-machines/disks-enable-host-based-encryption-portal.md
+++ b/articles/virtual-machines/disks-enable-host-based-encryption-portal.md
@@ -34,6 +34,21 @@ You must enable the feature for your subscription before you can use encryption 
 
    ![Screenshot of icon to launch the Cloud Shell from the Azure portal.](./media/disks-enable-host-based-encryption-portal/portal-launch-icon.png)
 
+1. Execute the following command to set context to current subscription
+
+   ### [Azure PowerShell](#tab/azure-powershell)
+
+   ```powershell
+   Set-AzContext -SubscriptionId "xxxx-xxxx-xxxx-xxxx"
+   ```
+
+   ### [Azure CLI](#tab/azure-cli)
+
+   ```azurecli
+   az account set --subscription "xxxx-xxxx-xxxx-xxxx"
+   ```
+   ---
+   
 1. Execute the following command to register the feature for your subscription
 
    ### [Azure PowerShell](#tab/azure-powershell)

--- a/articles/virtual-machines/disks-enable-host-based-encryption-portal.md
+++ b/articles/virtual-machines/disks-enable-host-based-encryption-portal.md
@@ -39,13 +39,13 @@ You must enable the feature for your subscription before you can use encryption 
    ### [Azure PowerShell](#tab/azure-powershell)
 
    ```powershell
-   Set-AzContext -SubscriptionId "xxxx-xxxx-xxxx-xxxx"
+   Set-AzContext -SubscriptionId "<yourSubIDHere>"
    ```
 
    ### [Azure CLI](#tab/azure-cli)
 
    ```azurecli
-   az account set --subscription "xxxx-xxxx-xxxx-xxxx"
+   az account set --subscription "<yourSubIDHere>"
    ```
    ---
    


### PR DESCRIPTION
If we can update this document explicitly defining that subscription for each context should be set in a certain way then it might help in future to have less problems. Had a ticket with Support team and even they couldn't tell me immediately what's the problem. And the problem was that I set context as az cli way and was registering feature via azure powershell and there was no error or hint to tell me that I'm enabling feature for wrong subscription. Ticket is RE: Cant create vm encryption at host - TrackingID#2411200050000262