### PR TITLE
Fix incorrect resource type in ARM template to create container group profile for standby pool

### DIFF
--- a/articles/container-instances/container-instances-standby-pool-create.md
+++ b/articles/container-instances/container-instances-standby-pool-create.md
@@ -79,7 +79,7 @@ Create a container group profile and save the template file. Deploy the template
   "contentVersion": "1.0.0.0",
   "resources": [
     {
-      "type": "Microsoft.ContainerInstance/containerGroups",
+      "type": "Microsoft.ContainerInstance/containerGroupProfiles",
       "apiVersion": "2024-05-01-preview",
       "name": "[parameters('profileName')]",
       "location": "[parameters('location')]",


### PR DESCRIPTION
[Create a standby pool for Azure Container Instances \(Preview\) \- Azure Container Instances \| Microsoft Learn](https://learn.microsoft.com/en-us/azure/container-instances/container-instances-standby-pool-create?tabs=template)
> Create a container group profile

The CLI, PowerShell, and REST commands describe creating `containerGroupProfiles`, but only the ARM template describes creating `containerGroups`.
