### PR TITLE
Update policy-reference.md

### DIFF
--- a/articles/virtual-machine-scale-sets/policy-reference.md
+++ b/articles/virtual-machine-scale-sets/policy-reference.md
@@ -1,6 +1,6 @@
 ---
-title: Built-in policy definitions for Azure Virtual Machine Scale Sets
-description: Lists Azure Policy built-in policy definitions for Azure Virtual Machine Scale Sets. These built-in policy definitions provide common approaches to managing your Azure resources.
+title: Built-in policy definitions for Azure Virtual Machine Scale Sets & Azure Virtual Machines
+description: Lists Azure Policy built-in policy definitions for Azure Virtual Machine Scale Sets & Azure Virtual Machines. These built-in policy definitions provide common approaches to managing your Azure resources.
 ms.topic: reference
 author: ju-shim
 ms.author: jushiman
@@ -12,7 +12,7 @@ ms.reviewer: mimckitt
 # Azure Policy built-in definitions for Azure Virtual Machine Scale Sets
 
 This page is an index of [Azure Policy](/azure/governance/policy/overview) built-in policy
-definitions for Azure Virtual Machine Scale Sets. For more Azure Policy built-ins for other
+definitions for Azure Virtual Machine Scale Sets & Azure Virtual Machines. For more Azure Policy built-ins for other
 services, see [Azure Policy built-in definitions](/azure/governance/policy/samples/built-in-policies).
 
 The name of each built-in policy definition links to the policy definition in the Azure portal. Use


### PR DESCRIPTION
Hello,

The public documentation “https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/policy-reference" has a misleading topic >> Azure policy built-in definitions for azure virtual machine scale set. however, those polices are not only targeting VMSS, but also VMs.

It seems that page links a mix of VMSS and normal VM policies, I checked a few policies randomly and they are both VMSS and VM depending on context, you can figure this out from the policy definition itself. 

This was highlighted by one of our Cx as well.