### PR TITLE
Update service fabric enlightened container documentation

### DIFF
--- a/articles/service-fabric/service-fabric-get-started-containers.md
+++ b/articles/service-fabric/service-fabric-get-started-containers.md
@@ -31,7 +31,7 @@ Running an existing application in a Windows container on a Service Fabric clust
   * [Service Fabric SDK and tools](service-fabric-get-started.md).
   *  Docker for Windows. [Get Docker CE for Windows (stable)](https://store.docker.com/editions/community/docker-ce-desktop-windows?tab=description). After installing and starting Docker, right-click on the tray icon and select **Switch to Windows containers**. This step is required to run Docker images based on Windows.
 
-* A Windows cluster with three or more nodes running on Windows Server with Docker installed. For more info on how to install Docker on the cluster, refer to [Installing Mirantis Runtime](https://github.com/Azure/Service-Fabric-Troubleshooting-Guides/blob/master/Deployment/Mirantis-Installation.md). 
+* A Windows cluster with three or more nodes running on Windows Server with Docker installed. For more information on how to install Docker on the cluster, refer to [Installing Mirantis Runtime](https://github.com/Azure/Service-Fabric-Troubleshooting-Guides/blob/master/Deployment/Mirantis-Installation.md). 
 
   For this article, the version (build) of Windows Server running on your cluster nodes must match that on your development machine. This is because you build the docker image on your development machine and there are compatibility constraints between versions of the container OS and the host OS on which it is deployed. For more information, see [Windows Server container OS and host OS compatibility](#windows-server-container-os-and-host-os-compatibility). 
   

--- a/articles/service-fabric/service-fabric-get-started-containers.md
+++ b/articles/service-fabric/service-fabric-get-started-containers.md
@@ -31,7 +31,7 @@ Running an existing application in a Windows container on a Service Fabric clust
   * [Service Fabric SDK and tools](service-fabric-get-started.md).
   *  Docker for Windows. [Get Docker CE for Windows (stable)](https://store.docker.com/editions/community/docker-ce-desktop-windows?tab=description). After installing and starting Docker, right-click on the tray icon and select **Switch to Windows containers**. This step is required to run Docker images based on Windows.
 
-* A Windows cluster with three or more nodes running on Windows Server that support containers. For more info on how to install Docker on the cluster, refer to [Installing Mirantis Runtime](https://github.com/Azure/Service-Fabric-Troubleshooting-Guides/blob/master/Deployment/Mirantis-Installation.md). 
+* A Windows cluster with three or more nodes running on Windows Server with Docker installed. For more info on how to install Docker on the cluster, refer to [Installing Mirantis Runtime](https://github.com/Azure/Service-Fabric-Troubleshooting-Guides/blob/master/Deployment/Mirantis-Installation.md). 
 
   For this article, the version (build) of Windows Server running on your cluster nodes must match that on your development machine. This is because you build the docker image on your development machine and there are compatibility constraints between versions of the container OS and the host OS on which it is deployed. For more information, see [Windows Server container OS and host OS compatibility](#windows-server-container-os-and-host-os-compatibility). 
   

--- a/articles/service-fabric/service-fabric-get-started-containers.md
+++ b/articles/service-fabric/service-fabric-get-started-containers.md
@@ -693,41 +693,6 @@ Similarly, below is an example on how to override the **ExeHost**:
 > [!NOTE]
 > Entry point override is not supported for SetupEntryPoint.
 
-## Configure Ktl logger to use user mode
-Stateful services can experience an error when running in containers because of the differences in the file system.
-This error will be visible inside the Service Fabric Explorer as follows:
-```
-'System.RA' reported Warning for property 'ReplicaOpenStatus'.
-Replica had multiple failures during open on _Type309_0. API call: IStatefulServiceReplica.Open(); Error = System.Fabric.FabricException (-2147024463)
-An error occurred during this operation.  Please check the trace logs for more details.
-System.Runtime.InteropServices.COMException (-2147024463)
-A device which does not exist was specified. (0x800701B1)
-...
-```
-The error can be fixed by updating the cluster manifest to set the **UseUserModeKtlLogger** to **true** under the **TransactionalReplicator** section.
-```json
-"fabricSettings": [
-	...,
-	{
-        "name": "TransactionalReplicator",
-        "parameters": [
-          {
-              "name": "UseUserModeKtlLogger",
-              "value": "true"
-          }
-          ...
-        ]
-	}
-]
-```
-
-## Primary certificate inside the container
-By default, the primary cluster certificate is needed for communication between nodes, and this certificate is not installed inside the containers. This means that Service Fabric Services running inside a container cannot talk to services on other nodes.
-
-A way to fix this is to include the pfx file inside the container along with a powershell script to install the certificate inside the container.
-
-Learn more about [Service Fabric cluster security scenarios](service-fabric-cluster-security.md).
-
 ## Next steps
 * Learn more about running [containers on Service Fabric](service-fabric-containers-overview.md).
 * Read the [Deploy a .NET application in a container](service-fabric-host-app-in-a-container.md) tutorial.

--- a/articles/service-fabric/service-fabric-services-inside-containers.md
+++ b/articles/service-fabric/service-fabric-services-inside-containers.md
@@ -16,7 +16,7 @@ Service Fabric supports containerizing Service Fabric microservices (Reliable Se
 This document provides guidance to get your service running inside a Windows container.
 
 > [!NOTE]
-> Currently this feature only works for Windows. To run containers, the cluster must be running on Windows Server with Docker installed. Refer to [Installing Mirantis Runtime](https://github.com/Azure/Service-Fabric-Troubleshooting-Guides/blob/master/Deployment/Mirantis-Installation.md)
+> Currently this feature only works for Windows. To run containers, the cluster must be running on Windows Server with Docker installed. Refer to [Installing Mirantis Runtime](https://github.com/Azure/Service-Fabric-Troubleshooting-Guides/blob/master/Deployment/Mirantis-Installation.md).
 
 ## Steps to containerize your Service Fabric Application
 
@@ -108,14 +108,12 @@ This document provides guidance to get your service running inside a Windows con
    </Policies>
    ```
    
-10. (Optional) Configure certificate for manual communication between services. <br>
-By default, the primary cluster certificate is needed for manual communication between different containerized services. This certificate is not installed inside the containers like it is on the node itself.
-One way to fix this is to include the .pfx file inside the container along with a powershell script to install the certificate inside the container.
+10. (Optional) Configure certificate for manual communication between services. By default, the primary cluster certificate is needed for manual communication between different containerized services. This certificate is not installed inside the containers like it is on the node itself.
+One way to fix this is to include the .pfx file inside the container along with a PowerShell script to install the certificate inside the container.
 Another way would be to configure the cluster such that the certificate is not required.
 Learn more about [Service Fabric cluster security scenarios](service-fabric-cluster-security.md).
 
-11. (Optional) Configure Ktl logger to use user mode <br>
-Stateful services can experience an error when running in containers because of the differences in the file system.
+11. (Optional) Configure Ktl logger to use user mode. Stateful services can experience an error when running in containers because of the differences in the file system.
 This error will be visible inside the Service Fabric Explorer as follows
     ```
      System.Runtime.InteropServices.COMException (-2147024463)
@@ -135,7 +133,7 @@ This error will be visible inside the Service Fabric Explorer as follows
       }
     ```
 
-12. To test this application, you need to deploy it to a cluster that is running version 5.7 or higher. For runtime versions 6.1 or lower, you need to edit and update the cluster settings to enable this preview feature. Follow the steps in this [article](service-fabric-cluster-fabric-settings.md) to add the setting shown next.
+12. To test this application, you need to deploy it to a cluster that is running version 5.7 or higher. For runtime versions 6.1 or lower, you need to edit and update the cluster settings to enable this preview feature. Follow the steps in [this article](service-fabric-cluster-fabric-settings.md) to add the setting shown next.
     ```json
       {
         "name": "Hosting",
@@ -151,7 +149,7 @@ This error will be visible inside the Service Fabric Explorer as follows
 13. Next [deploy](service-fabric-deploy-remove-applications.md) the edited application package to this cluster.
 
 > [!NOTE]
-> A Service Fabric cluster is single tenant by design and hosted applications are considered **trusted**. If you are considering hosting **untrusted container applications**, consider deploying them as [guest containers](service-fabric-containers-overview.md#service-fabric-support-for-containers) and please see [Hosting untrusted applications in a Service Fabric cluster](service-fabric-best-practices-security.md#hosting-untrusted-applications-in-a-service-fabric-cluster).
+> A Service Fabric cluster is single tenant by design and hosted applications are considered **trusted**. If you are considering hosting **untrusted container applications**, consider deploying them as [guest containers](service-fabric-containers-overview.md#service-fabric-support-for-containers) and see [Hosting untrusted applications in a Service Fabric cluster](service-fabric-best-practices-security.md#hosting-untrusted-applications-in-a-service-fabric-cluster).
 
 You should now have a containerized Service Fabric application running your cluster.
 

--- a/articles/service-fabric/service-fabric-services-inside-containers.md
+++ b/articles/service-fabric/service-fabric-services-inside-containers.md
@@ -108,9 +108,10 @@ This document provides guidance to get your service running inside a Windows con
    </Policies>
    ```
    
-10. (Optional) Primary certificate inside the container <br>
-By default, the primary cluster certificate is needed for communication between nodes, and this certificate is not installed inside the containers. This means that Service Fabric Services running inside a container cannot talk to services on other nodes.
-A way to fix this is to include the pfx file inside the container along with a powershell script to install the certificate inside the container.
+10. (Optional) Configure certificate for manual communication between services. <br>
+By default, the primary cluster certificate is needed for manual communication between different containerized services. This certificate is not installed inside the containers like it is on the node itself.
+One way to fix this is to include the .pfx file inside the container along with a powershell script to install the certificate inside the container.
+Another way would be to configure the cluster such that the certificate is not required.
 Learn more about [Service Fabric cluster security scenarios](service-fabric-cluster-security.md).
 
 11. (Optional) Configure Ktl logger to use user mode <br>


### PR DESCRIPTION
While following the documentation to learn about enlightened containers, I noticed a few things that are outdated, as well as a few common issues that should be mentioned to aid the users in debugging the problem.
I made the following changes:
- Removed references to "Windows Server with Containers" as this is no longer available. Instead, users should use a guide to install Docker automatically on containers.
- Added 2 optional steps when containerizing the service that I had to do in order for my service to work. Maybe these should be included in some "troubleshooting" section at the bottom as they don't apply to all use cases.