### PR TITLE
Update oracle-database-quick-create.md

### DIFF
--- a/articles/virtual-machines/workloads/oracle/oracle-database-quick-create.md
+++ b/articles/virtual-machines/workloads/oracle/oracle-database-quick-create.md
@@ -97,7 +97,6 @@ In this task, you must configure some external endpoints for the database listen
    ```azurecli-interactive
    az network nsg create --resource-group rg-oracle --name vmoracle19cNSG
    ```
-
 1. Create an NSG rule with the [az network nsg rule create](/cli/azure/network/nsg/rule#az-network-nsg-rule-create) command. This command creates the **allow-oracle** NSG rule to open the endpoint for remote access to the Oracle database:
 
    ```azurecli-interactive
@@ -121,7 +120,17 @@ In this task, you must configure some external endpoints for the database listen
        --priority 1002 \
        --destination-port-range 5502
    ```
+1. Create an NSG rule with the [az network nsg rule create](/cli/azure/network/nsg/rule#az-network-nsg-rule-create) command. This command creates the **allow-ssh** NSG rule to open the endpoint for remote access via ssh:
 
+   ```azurecli-interactive
+   az network nsg rule create \
+       --resource-group rg-oracle \
+       --nsg-name vmoracle19cNSG \
+       --name allow-ssh \
+       --protocol tcp \
+       --priority 1001 \
+       --destination-port-range 22
+   ```
 1. As needed, use the [az network public-ip show](/cli/azure/network/public-ip#az-network-public-ip-show) command to get the public IP address of your VM:
 
    ```azurecli-interactive


### PR DESCRIPTION
Adding an NSG SSH rule that was missing. Without this rule people can't connect via ssh to the vm