### PR TITLE
Fix incorrect codename of EPYC 7763v

### DIFF
--- a/articles/virtual-machines/sizes/general-purpose/includes/basv2-series-specs.md
+++ b/articles/virtual-machines/sizes/general-purpose/includes/basv2-series-specs.md
@@ -12,7 +12,7 @@ ms.custom: include file
 ---
 | Part | Quantity <br><sup>Count Units | Specs <br><sup>SKU ID, Performance Units, etc.  |
 |---|---|---|
-| Processor      | 2 - 32 vCPUs       | AMD EPYC 7763v (Genoa) [x86-64]                               |
+| Processor      | 2 - 32 vCPUs       | AMD EPYC 7763v (Milan) [x86-64]                               |
 | Memory         | 1 - 128 GiB          |                                  |
 | Local Storage  | None           |                                |
 | Remote Storage | 4 - 32 Disks    | 3750 - 25,600 IOPS <br>85 - 600 MBps   |

--- a/articles/virtual-machines/sizes/general-purpose/includes/dasv4-series-specs.md
+++ b/articles/virtual-machines/sizes/general-purpose/includes/dasv4-series-specs.md
@@ -12,7 +12,7 @@ ms.custom: include file
 ---
 | Part | Quantity <br><sup>Count Units | Specs <br><sup>SKU ID, Performance Units, etc.  |
 |---|---|---|
-| Processor      | 2 - 96 vCPUs       | AMD EPYC 7452 (Rome) [x86-64] <br>AMD EPYC 7763v (Genoa) [x86-64]                               |
+| Processor      | 2 - 96 vCPUs       | AMD EPYC 7452 (Rome) [x86-64] <br>AMD EPYC 7763v (Milan) [x86-64]                               |
 | Memory         | 8 - 384 GiB          |                                  |
 | Local Storage  | 4 - 32 Disks           | 16 - 768 GiB <br>4000 - 192000 IOPS (RR) <br>32 - 1020 MBps (RR)                               |
 | Remote Storage | 4 - 32 Disks    | 3200 - 80000 IOPS <br>48 - 1200 MBps   |

--- a/articles/virtual-machines/sizes/memory-optimized/includes/easv5-series-specs.md
+++ b/articles/virtual-machines/sizes/memory-optimized/includes/easv5-series-specs.md
@@ -12,7 +12,7 @@ ms.custom: include file
 ---
 | Part | Quantity <br><sup>Count Units | Specs <br><sup>SKU ID, Performance Units, etc.  |
 |---|---|---|
-| Processor      | 2 - 112 vCPUs     | AMD EPYC 7763v (Genoa) [x86-64] |
+| Processor      | 2 - 112 vCPUs     | AMD EPYC 7763v (Milan) [x86-64] |
 | Memory         | 16 - 672 GiB        |    |
 | Local Storage  | None         |  |
 | Remote Storage | 4 - 64 Disks        | 3750 - 120000 IOPS <br>82 - 2000 MBps |

--- a/articles/virtual-machines/sizes/storage-optimized/includes/lasv3-series-specs.md
+++ b/articles/virtual-machines/sizes/storage-optimized/includes/lasv3-series-specs.md
@@ -12,7 +12,7 @@ ms.custom: include file
 ---
 | Part | Quantity <br><sup>Count Units | Specs <br><sup>SKU ID, Performance Units, etc.  |
 |---|---|---|
-| Processor      | 8 - 80 vCPUs       | AMD EPYC 7763v (Genoa) [x86-64]                               |
+| Processor      | 8 - 80 vCPUs       | AMD EPYC 7763v (Milan) [x86-64]                               |
 | Memory         | 64 - 640 GiB          |                                  |
 | Local Storage  | 1 Temp Disk <br> 1 - 10 NVMe Disks          | 80 - 800 GiB Temp Disks <br> 1.92 TiB NVMe Disks                |
 | Remote Storage | 16 - 32 Disks    | 12800 - 80000 IOPS <br>200 - 1400 MBps   |


### PR DESCRIPTION
EPYC 776**3**v belongs to the **3**rd generation of AMD EPYC family, whose codename should be Milan instead of Genoa. Genoa is the codename of 9004 family.