### PR TITLE
Update image-builder.md - Add a sleep delay to the customizations script

### DIFF
--- a/articles/virtual-machines/linux/image-builder.md
+++ b/articles/virtual-machines/linux/image-builder.md
@@ -155,6 +155,7 @@ sed -i -e "s/<region1>/$location/g" helloImageTemplateforSIG.json
 sed -i -e "s/<region2>/$additionalregion/g" helloImageTemplateforSIG.json
 sed -i -e "s/<runOutputName>/$runOutputName/g" helloImageTemplateforSIG.json
 sed -i -e "s%<imgBuilderId>%$imgBuilderId%g" helloImageTemplateforSIG.json
+sed -i -e "s/sudo mkdir/sleep 300;sudo mkdir/g" helloImageTemplateforSIG.json
 ```
 
 ## Create the image version


### PR DESCRIPTION
This executes too rapidly and many times the image isn't ready for the quickstart json to run inside the VM.  You end up with a (PackerBuildFailed) and if you look in the customization.log, you'll see messages like the below.  If the OS  just has a little bit of time to fully come up, though, before the customizations, the error goes away.  

[7111a125-9cce-4cc6-80f1-70030c08e815] PACKER 2025/03/18 20:42:48 ui:     azure-arm: E: Could not open file /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_focal-updates_main_i18n_Translation-en - open (2: No such file or directory)
[7111a125-9cce-4cc6-80f1-70030c08e815] PACKER 2025/03/18 20:42:48 ui:     azure-arm: E: Could not open file /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_focal-updates_main_binary-amd64_Packages - open (2: No such file or directory)
[7111a125-9cce-4cc6-80f1-70030c08e815] PACKER 2025/03/18 20:42:48 ui:     azure-arm: E: Could not open file /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_focal_restricted_i18n_Translation-en - open (2: No such file or directory)
[7111a125-9cce-4cc6-80f1-70030c08e815] PACKER 2025/03/18 20:42:48 ui:     azure-arm: E: Could not open file /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_focal_restricted_binary-amd64_Packages - open (2: No such file or directory)
[7111a125-9cce-4cc6-80f1-70030c08e815] PACKER 2025/03/18 20:42:48 ui:     azure-arm: E: Could not open file /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_focal_main_i18n_Translation-en - open (2: No such file or directory)
[7111a125-9cce-4cc6-80f1-70030c08e815] PACKER 2025/03/18 20:42:48 ui:     azure-arm: E: Could not open file /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_focal_main_binary-amd64_Packages - open (2: No such file or directory)
[7111a125-9cce-4cc6-80f1-70030c08e815] PACKER 2025/03/18 20:42:48 [INFO] 2138 bytes written for 'stdout'
[7111a125-9cce-4cc6-80f1-70030c08e815] PACKER 2025/03/18 20:42:48 packer-plugin-azure_v2.2.0_x5.0_linux_amd64 plugin: 2025/03/18 20:42:48 [ERROR] Remote command exited with '100': chmod +x /tmp/script_3400.sh; sudo '/tmp/script_3400.sh'
[7111a125-9cce-4cc6-80f1-70030c08e815] PACKER 2025/03/18 20:42:48 packer-plugin-azure_v2.2.0_x5.0_linux_amd64 plugin: 2025/03/18 20:42:48 [INFO] RPC endpoint: Communicator ended with: 100
[7111a125-9cce-4cc6-80f1-70030c08e815] PACKER 2025/03/18 20:42:48 [INFO] 0 bytes written for 'stderr'