### PR TITLE
Specify HyperVGeneration = 'v1'

### DIFF
--- a/articles/virtual-machines/windows/image-builder-powershell.md
+++ b/articles/virtual-machines/windows/image-builder-powershell.md
@@ -182,6 +182,7 @@ Grant Azure image builder permissions to create images in the specified resource
      Publisher = 'myCo'
      Offer = 'Windows'
      Sku = 'Win2019'
+     HyperVGeneration = 'v1'
    }
    New-AzGalleryImageDefinition @GalleryParams
    ```


### PR DESCRIPTION
If you do not specify HyperVGeneration = 'v1' in the $GalleryParams, you'll receive the error message   Validation failed: Error with Hyper-V Version validation (cross-generation for multiple Hyper-V Versions is not supported). The provided SIG:
     | /subscriptions/REDACTED/resourceGroups/myWinImgBuilderRG/providers/Microsoft.Compute/galleries/myImageGallery/images/winSvrImages, has a different Hyper-V Generation: V2,
     | than source image: V1.