### PR TITLE
Update image used

### DIFF
--- a/articles/virtual-machines/windows/image-builder-virtual-desktop.md
+++ b/articles/virtual-machines/windows/image-builder-virtual-desktop.md
@@ -230,6 +230,7 @@ Invoke-WebRequest -Uri $templateUrl -OutFile $templateFilePath -UseBasicParsing
 ((Get-Content -path $templateFilePath -Raw) -replace '<sharedImageGalName>',$sigGalleryName) | Set-Content -Path $templateFilePath
 ((Get-Content -path $templateFilePath -Raw) -replace '<region1>',$location) | Set-Content -Path $templateFilePath
 ((Get-Content -path $templateFilePath -Raw) -replace '<imgBuilderId>',$identityNameResourceId) | Set-Content -Path $templateFilePath
+((Get-Content -path $templateFilePath -Raw) -replace '20h1-ent','win10-21h2-ent-g2') | Set-Content -Path $templateFilePath
 
 ```
 


### PR DESCRIPTION
Platform image 20h1-ent is no longer present, so will want to update or it will fail.  Also, as we now default to generation 2, will want to make sure the image is g2 or it will also fail.  win10-21h2-ent-g2 works for now.