### PR TITLE
Add reboot command after the NVIDIA GPU driver installation

### DIFF
--- a/articles/virtual-machines/linux/n-series-driver-setup.md
+++ b/articles/virtual-machines/linux/n-series-driver-setup.md
@@ -59,8 +59,11 @@ Ubuntu packages NVIDIA proprietary drivers. Those drivers come directly from NVI
    ```bash
    sudo ubuntu-drivers install
    ```
-   Reboot the VM after the GPU driver is installed.
-3. Download and install the CUDA toolkit from NVIDIA:
+3. Reboot the VM after the GPU driver is installed:
+   ```bash
+   sudo reboot
+   ```
+4. Download and install the CUDA toolkit from NVIDIA:
     > [!NOTE]
    >  The example shows the CUDA package path for Ubuntu 24.04 LTS. Replace the path specific to the version you plan to use.
    >
@@ -75,12 +78,12 @@ Ubuntu packages NVIDIA proprietary drivers. Those drivers come directly from NVI
 
    The installation can take several minutes.
 
-4. Reboot the VM after installation completes:
+5. Reboot the VM after installation completes:
    ```bash
    sudo reboot
    ```
 
-5. Verify that the GPU is correctly recognized (after reboot):
+6. Verify that the GPU is correctly recognized (after reboot):
    ```bash
    nvidia-smi
    ```


### PR DESCRIPTION
After GPU Driver installation, the document mentions in English statement to reboot the VM, which can get missed by the users when utilizing the document. To ensure users do not miss the step, added the explicit, `sudo reboot` command after the GPU driver installation step.