### PR TITLE
Update generation-2.md

### DIFF
--- a/articles/virtual-machines/generation-2.md
+++ b/articles/virtual-machines/generation-2.md
@@ -29,7 +29,7 @@ Azure now offers Generation 2 support for the following selected VM series:
 |[B-series](sizes-b-series-burstable.md) |  :heavy_check_mark:  | :heavy_check_mark: |
 |[DCsv2-series](dcv2-series.md) |  :x:  | :heavy_check_mark: |
 |[Dv2-series](dv2-dsv2-series.md) |  :heavy_check_mark: |  :x:  |
-|[DSv2-series](dv2-dsv2-series.md) |  :heavy_check_mark: | :heavy_check_mark: |
+|[DSv2-series](dsv2-series.md) |  :heavy_check_mark: | :x: |
 |[Dv3-series](dv3-dsv3-series.md) | :heavy_check_mark: |  :x: |
 |[Dsv3-series](dv3-dsv3-series.md) | :heavy_check_mark: | :heavy_check_mark: |
 |[Dv4-series](dv4-dsv4-series.md) | :heavy_check_mark: |  :heavy_check_mark: |


### PR DESCRIPTION
This 

1. Fixes the link, instead of wrong https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dv2-series?tabs=sizebasic it points to https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dsv2-series?tabs=sizebasic
2. DSv2 dedicated page says it's Gen1 only, meanwhile the table says it's both. I believe the first is right, but if it's actually Gen2 too, please correct the other page to mention Gen2 too. 