### PR TITLE
Update Canonical Ubuntu LTS end-of-support guidance

### DIFF
--- a/articles/virtual-machines/workloads/canonical/ubuntu-els-guidance.md
+++ b/articles/virtual-machines/workloads/canonical/ubuntu-els-guidance.md
@@ -13,33 +13,34 @@ ms.author: carols
 
 # Canonical Ubuntu LTS end of standard support guidance 
 
-Long-term support (LTS) releases of Ubuntu Server receive standard security updates for five years by default. Every six months, interim releases bring new features, while hardware enablement updates add support for the latest machines to all supported LTS releases. 
+Long-term support (LTS) releases of Ubuntu receive standard security maintenance for packages in the Ubuntu Main repository for five years from the release date. Every six months between LTS releases, interim releases bring new features for testing and development. Hardware enablement (HWE) updates, providing newer kernel and graphics stacks, are made available for supported LTS releases. 
 
-When an Ubuntu release reaches the end of its standard support, the following applies: You can continue to use your existing virtual machines; however, security, feature, and maintenance updates will no longer be provided by Canonical. This may leave your systems vulnerable.  
+When an Ubuntu LTS release reaches the end of its standard support period, the following applies: You can continue to use your existing virtual machines; however, security, feature, and maintenance updates will no longer be provided by Canonical under standard support. This may leave your systems vulnerable.  
 
-You'll want to consider either migrating to the next Ubuntu LTS release, or upgrading to Ubuntu Pro to gain access to expanded security and maintenance from Canonical.   
+You should consider either migrating to a supported Ubuntu LTS release, or enabling Ubuntu Pro to gain access to expanded security and maintenance and other features from Canonical.   
 
 ## Upgrading to a newer Ubuntu LTS 
 
-Transitioning to the latest operating system, is important for performance, hardware enablement, new technology benefits, and is recommended for new instances. It could be a complex process for existing deployments and should be properly scoped and tested with your workloads.   
+Transitioning to the latest operating system is important for performance, hardware enablement, access to new technology, and is recommended for new instances. Upgrading could be a complex process for existing deployments and should be properly scoped and tested with your workloads.   
 
-You can only directly upgrade one version of Ubuntu LTS to the next version. For instance, if you're running Ubuntu 18.04 LTS, you can't upgrade directly to Ubuntu 22.04 LTS. You would have to first upgrade your Ubuntu 18.04 LTS to Ubuntu 20.04 LTS and then you could upgrade to Ubuntu 22.04 LTS. 
+You can only directly upgrade one version of Ubuntu LTS to the next version. For instance, upgrading from Ubuntu 20.04 LTS to Ubuntu 24.04 LTS requires a two-step process: first upgrade Ubuntu 20.04 LTS to Ubuntu 22.04 LTS, and then upgrade from Ubuntu 22.04 LTS to Ubuntu 24.04 LTS. 
 
 See the [Ubuntu Server upgrade guide](https://ubuntu.com/server/docs/how-to-upgrade-your-release) for more information.  
 
 ## Ubuntu Pro – expanded security maintenance for LTS releases
 
-Ubuntu Pro includes security patching for all Ubuntu packages due to Expanded Security Maintenance (ESM) for Infrastructure and Applications and optional 24/7 phone and ticket support. Ubuntu Pro adds an extra five years of support to an Ubuntu LTS release, for a total of 10 years of support. 
+Ubuntu Pro is a subscription that expands Canonical's security maintenance coverage and provides optional support. It includes Expanded Security Maintenance (ESM) providing security patching for critical, high, and selected medium CVEs for packages in both the Ubuntu Main and Universe repositories. Ubuntu Pro extends the security coverage period for an Ubuntu LTS release up to a total of 12 years. Optional 24/7 phone and ticket support plans are also available with Ubuntu Pro.
 
-New virtual machines can be deployed with Ubuntu Pro from the Azure Marketplace. You can also upgrade Ubuntu Server (version 16.04 or higher) virtual machines to Ubuntu Pro without redeployment or downtime. See the [Ubuntu Server to Ubuntu Pro in-place upgrade on Azure guide](ubuntu-pro-in-place-upgrade.md) for more information.
+New virtual machines can be deployed with Ubuntu Pro from the Azure Marketplace. You can also upgrade existing Ubuntu Server (version 16.04 LTS or higher) virtual machines to Ubuntu Pro without redeployment or downtime. See the [Ubuntu Server to Ubuntu Pro in-place upgrade on Azure guide](ubuntu-pro-in-place-upgrade.md) for more information.
 
 
 | **Ubuntu LTS Release** | **End of Standard Support** | **End of Ubuntu Pro Support** |
 |---|---|---|
-| 24.04   | April 2029 | April 2034|
+| 24.04   | May 2029 | April 2034|
 | 22.04   |  May 2027 | April 2032 |
 | 20.04   | May 2025  | April 2030 |
 | 18.04   | May 2023  | April 2028 |
+| 16.04   | May 2021  | April 2026 |
 
 
 ## More information  


### PR DESCRIPTION
This pull request updates the documentation page detailing the end-of-standard-support lifecycle for Canonical Ubuntu LTS releases on Azure.

The key modifications include:

* Corrected a typographical error in the description of implications when a release reaches end of standard support.
* Updated the introductory paragraphs to refine definitions related to standard maintenance scope (Ubuntu Main repository), interim releases, and Hardware Enablement (HWE).
* Updated the example illustrating the LTS upgrade path to use the sequence from Ubuntu 20.04 LTS through 22.04 LTS to 24.04 LTS.
* Revised the section describing Ubuntu Pro, clarifying the scope of Expanded Security Maintenance (ESM) across Main and Universe repositories, CVE coverage details, and the stated total support duration.
* Updated the lifecycle table to include Ubuntu 16.04 LTS and reflect the end-of-support dates as presented in the document.
* General minor wording adjustments for improved clarity and flow.