### PR TITLE
Update enable-nvme-interface.md

### DIFF
--- a/articles/virtual-machines/enable-nvme-interface.md
+++ b/articles/virtual-machines/enable-nvme-interface.md
@@ -38,6 +38,7 @@ For more information about enabling the NVMe interface on virtual machines creat
 - Ubuntu 22.04
 
 ## Supported Windows OS images
+- Windows Server 2025
 - Windows Server 2019*
 - Windows Server 2022
 - Windows 10


### PR DESCRIPTION
One of my customer has deployed a VM with SKU Size Standard_D2ls_v6 and Windows Server 2025. 

This SKU size comes with NVMe enabled by default and this combination (NVMe + 2025 OS) seems to have some issue. 

Unable to RDP, Desktop freezes when added data disks etc.,

We resized the VM SKU to Standard_D2ls_v5 and VM looks stable.  Question here is that, our Public Document doesn't have 2025 as supported OS images.

Can you please validate this and add accordingly. I am provide additional details if required.

Thank you in advance.