### PR TITLE
Update dsv2-series.md

### DIFF
--- a/articles/virtual-machines/sizes/general-purpose/dsv2-series.md
+++ b/articles/virtual-machines/sizes/general-purpose/dsv2-series.md
@@ -20,7 +20,7 @@ ms.reviewer: mattmcinnes
 
 ## Feature support
 
-Premium Storage: Not Supported<br>
+Premium Storage: Supported<br>
 Premium Storage caching: Not Supported<br>
 Live Migration: Supported<br>
 Memory Preserving Updates: Supported<br>


### PR DESCRIPTION
The Dsv2 Series does support Premium disks. The "s" in Dsv2 (e.g., DS2_v2) stands for Premium Storage support. The Document had a typo and had mentioned that it does not support Premium disks.

Also, the document - https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dsv2-series?tabs=sizebasic keeps reference the series SKU Dv2 whereas is should be referencing it as DSv2 Series SKU.