### PR TITLE
Fix issue with support statement for EAH.

### DIFF
--- a/articles/virtual-machines/includes/virtual-machines-disks-encryption-at-host-restrictions.md
+++ b/articles/virtual-machines/includes/virtual-machines-disks-encryption-at-host-restrictions.md
@@ -10,7 +10,7 @@ ms.custom:
   - include file
   - ignite-2023
 ---
-- Supported for 4k sector size Ultra Disks and Premium SSD v2.
+- When using Ultra Disks and Premium SSD v2 only 4k sector sizes are supported.
 - Only supported on 512e sector size Ultra Disks and Premium SSD v2 if they were created after 5/13/2023.
     - For disks created before this date, [snapshot your disk](/azure/virtual-machines/disks-incremental-snapshots) and create a new disk using the snapshot.
 - Can't be enabled on virtual machines (VMs) or virtual machine scale sets that currently or ever had Azure Disk Encryption enabled. 


### PR DESCRIPTION
Provide clarity that the 4k sector size bit only applies to Premium SSDv2 and Ultra Disks. All other disks are also supported.

What, I guess, we meant to say here is something like "if you are using Ultra Disks or Premium SSD v2, we only support 4k sector sizes."
 
How our team and customer interpreted this is "this feature is only supported for Premium SSDv2 and Ultra Disks and not for any other disk types, that's not good!" 