### PR TITLE
Fix SFBinaryLoader initialization in service-fabric-services-inside-containers.md

### DIFF
--- a/articles/service-fabric/service-fabric-services-inside-containers.md
+++ b/articles/service-fabric/service-fabric-services-inside-containers.md
@@ -30,19 +30,18 @@ This document provides guidance to get your service running inside a Windows con
    ```csharp
    namespace MyApplication
    {
-      using StatelessContainer;
-      public class Program
+      internal static class Program
       {
-          public static void Main(string[] args)
+          private static void Main()
           {
               SFBinaryLoader.Initialize();
-              RealMain(args);
+              RealMain();
           }
 
           /// <summary>
           /// This is the entry point of the service host process.
           /// </summary>
-          private static void RealMain(string[] args)
+          private static void RealMain()
           {
    ```
 

--- a/articles/service-fabric/service-fabric-services-inside-containers.md
+++ b/articles/service-fabric/service-fabric-services-inside-containers.md
@@ -25,22 +25,24 @@ This document provides guidance to get your service running inside a Windows con
 
 2. Add class [SFBinaryLoader.cs](https://github.com/Azure/service-fabric-scripts-and-templates/blob/master/code/SFBinaryLoaderForContainers/SFBinaryLoader.cs) to your project. The code in this class is a helper to correctly load the Service Fabric runtime binaries inside your application when running inside a container.
 
-3. For each code package you would like to containerize, initialize the loader at the program entry point. Add the static constructor shown in the following code snippet to your program entry point file.
+3. For each code package you would like to containerize, initialize the loader at the program entry point. Add a new Main function to your Program.cs and rename the old Main to RealMain, like in the example below. This is required to delay loading any Service Fabric dependencies until the SFBinaryLoader is initialized.
 
    ```csharp
    namespace MyApplication
    {
-      internal static class Program
+      using StatelessContainer;
+      public class Program
       {
-          static Program()
+          public static void Main(string[] args)
           {
               SFBinaryLoader.Initialize();
+              RealMain(args);
           }
 
           /// <summary>
           /// This is the entry point of the service host process.
           /// </summary>
-          private static void Main()
+          private static void RealMain(string[] args)
           {
    ```
 


### PR DESCRIPTION
Add correct SFBinaryLoader initialization for new Program.cs versions.
For the new version, the old version with the static initialization didn't work, the Program tried to load the ServiceFabric dll before the initialization.
With this new version, both old and new versions should work.