### PR TITLE
Correcting the remote disk count of Standard_ND128isr_NDR_GB200_v6

### DIFF
--- a/articles/virtual-machines/sizes/gpu-accelerated/nd-gb200-v6-series.md
+++ b/articles/virtual-machines/sizes/gpu-accelerated/nd-gb200-v6-series.md
@@ -59,7 +59,7 @@ Remote (uncached) storage info for each size
 
 | Size Name | Max Remote Storage Disks (Qty.) | Uncached Disk IOPS | Uncached Disk Speed (MBps) |
 | --- | --- | --- | --- |
-| Standard_ND128isr_NDR_GB200_v6 | 316 | 80000 | 1200 |
+| Standard_ND128isr_NDR_GB200_v6 | 16 | 80000 | 1200 |
 
 #### Storage resources
 - [Introduction to Azure managed disks](../../../virtual-machines/managed-disks-overview.md)


### PR DESCRIPTION
Standard_ND128isr_NDR_GB200_v6 supports only 16 remote disks.