### PR TITLE
Update time-sync.md

### DIFF
--- a/articles/virtual-machines/linux/time-sync.md
+++ b/articles/virtual-machines/linux/time-sync.md
@@ -171,7 +171,7 @@ For more information about chrony, see [Using chrony](https://access.redhat.com/
 
 ### systemd 
 
-On SUSE and Ubuntu releases before 19.10, time sync is configured using [systemd](https://www.freedesktop.org/wiki/Software/systemd/). For more information about Ubuntu, see [Time Synchronization](https://help.ubuntu.com/lts/serverguide/NTP.html). For more information about SUSE, see Section 4.5.8 in [SUSE Linux Enterprise Server 12 SP3 Release Notes](https://www.suse.com/releasenotes/x86_64/SUSE-SLES/12-SP3/#InfraPackArch.ArchIndependent.SystemsManagement).
+On SUSE and Ubuntu releases before 19.10, time sync is configured using [systemd](https://www.freedesktop.org/wiki/Software/systemd/). For more information about Ubuntu, see [Time Synchronization](https://help.ubuntu.com/lts/serverguide/NTP.html). For more information about SUSE, see [Time Synchronization in SUSE](https://documentation.suse.com/smart/network/html/ntp-time-synchronization/index.html).
 
 ### cloud-init
 


### PR DESCRIPTION
The information provided in https://docs.azure.cn/en-us/virtual-machines/linux/time-sync#systemd  for SUSE is outdated and does not accurately provide right info. Also, 12 SP3 is EOL. For updated guidance on time synchronization using chronyd/systemd, please refer to the revised documentation provided by SUSE.