### PR TITLE
Updated the New-AzGalleryImageVersion Powershell command

### DIFF
--- a/articles/virtual-machines/windows/tutorial-custom-images.md
+++ b/articles/virtual-machines/windows/tutorial-custom-images.md
@@ -114,12 +114,13 @@ Allowed characters for image version are numbers and periods. Numbers must be wi
 
 In this example, the image version is *1.0.0* and it's replicated to both *East US* and *South Central US* datacenters. When choosing target regions for replication, you need to include the *source* region as a target for replication.
 
-To create an image version from the VM, use `$vm.Id.ToString()` for the `-Source`.
+To create an image version from the VM, use source VM's resource id for -sourceImageVMId.
 
 ```azurepowershell-interactive
    $region1 = @{Name='South Central US';ReplicaCount=1}
    $region2 = @{Name='East US';ReplicaCount=2}
    $targetRegions = @($region1,$region2)
+   $sourceImageVMId = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGalleryRG/providers/Microsoft.Compute/virtualMachines/sourceVM"
 
 New-AzGalleryImageVersion `
    -GalleryImageDefinitionName $galleryImage.Name`
@@ -128,7 +129,7 @@ New-AzGalleryImageVersion `
    -ResourceGroupName $resourceGroup.ResourceGroupName `
    -Location $resourceGroup.Location `
    -TargetRegion $targetRegions  `
-   -Source $sourceVM.Id.ToString() `
+   -SourceImageVMId $sourceImageVMId `
    -PublishingProfileEndOfLifeDate '2030-12-01'
 ```
 


### PR DESCRIPTION
Updated the New-AzGalleryImageVersion Powershell command.

It is mentioned as -

New-AzGalleryImageVersion `
   -GalleryImageDefinitionName $galleryImage.Name`
   -GalleryImageVersionName '1.0.0' `
   -GalleryName $gallery.Name `
   -ResourceGroupName $resourceGroup.ResourceGroupName `
   -Location $resourceGroup.Location `
   -TargetRegion $targetRegions  `
   -Source $sourceVM.Id.ToString() `
   -PublishingProfileEndOfLifeDate '2030-12-01'

When we run the above command, we get the error -

 New-AzGalleryImageVersion -GalleryImageDefinitionName $galleryImage.Name -GalleryImageVersionName '1.0.0' -GalleryName $gallery.Name -ResourceGroupName $resourceGroup.ResourceGroupName -Location $resourceGroup.Location -TargetRegion $targetRegions -Source $sourceVM.Id.ToString() -PublishingProfileEndOfLifeDate '2030-12-01'
New-AzGalleryImageVersion: Parameter cannot be processed because the parameter name 'Source' is ambiguous. Possible matches include: -SourceImageId -SourceImageVMId.

When checked the document for New-AzGalleryImageVersion, we could see below parameters -

New-AzGalleryImageVersion
    [-ResourceGroupName] <String>
    [-GalleryName] <String>
    [-GalleryImageDefinitionName] <String>
    [-Name] <String>
    [-AsJob]
    -Location <String>
    [-DataDiskImage <GalleryDataDiskImage[]>]
    [-OSDiskImage <GalleryOSDiskImage>]
    [-PublishingProfileEndOfLifeDate <DateTime>]
    [-PublishingProfileExcludeFromLatest]
    [-ReplicaCount <Int32>]
    [-SourceImageId <String>]
    [-SourceImageVMId <String>]
    [-StorageAccountType <String>]
    [-Tag <Hashtable>]
    [-TargetRegion <Hashtable[]>]
    [-TargetExtendedLocation <Hashtable[]>]
    [-DefaultProfile <IAzureContextContainer>]
    [-WhatIf]
    [-Confirm]
    [<CommonParameters>]

There is no parameter as -Source.