### PR TITLE
Add commands to check decryption progress in Linux data disk decryption steps warning

### DIFF
--- a/articles/virtual-machines/linux/disk-encryption-linux.md
+++ b/articles/virtual-machines/linux/disk-encryption-linux.md
@@ -428,6 +428,8 @@ You can disable encryption using Azure PowerShell, the Azure CLI, or with a Reso
 
 > [!WARNING]
 > Once decryption starts, it is advisable not to interfere with the process.
+>
+> To check the progress of decryption, use the [Get-AzVMDiskEncryptionStatus](https://learn.microsoft.com/powershell/module/az.compute/get-azvmdiskencryptionstatus) PowerShell cmdlet or the [az vm encryption show](https://learn.microsoft.com/en-us/cli/azure/vm/encryption?view=azure-cli-latest#az-vm-encryption-show) CLI command, once the decryption process is completed, you can proceed to remove the encryption extension
 
 ### Remove the encryption extension
 


### PR DESCRIPTION
In the Linux Encryption steps, we provide the commands to enable the encryption and then in the same section we provide the commands to monitor the encryption progress with PS cmdlet and with Azure CLI: [Enable encryption on an existing or running Linux VM](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/disk-encryption-linux?tabs=azcliazure%2Cenableadecli%2Cefacli%2Cadedatacli#enable-encryption-on-an-existing-or-running-linux-vm)

However, we do not have that in the Linux decryption steps: [Disable encryption
](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/disk-encryption-linux?tabs=azcliazure%2Cenableadecli%2Cefacli%2Cadedatacli#disable-encryption) there is a warning that suggests that "Once decryption starts, it is advisable not to interfere with the process", but it would be useful to add a note in the warning mentioning that they can monitor the process and with a link to the commands used to check the decryption progress, something like this:

'To check the progress of decryption, use the Get-AzVMDiskEncryptionStatus PowerShell cmdlet or the vm encryption show CLI command, once the decryption process is completed, you can proceed to remove the encryption extension'

I have had cases where customers get confused with the 'succeeded' output of the decryption command execution and proceed to remove the encryption extension when the data disks are still in progress to be decrypted.