### PR TITLE
Update disks-shared.md

### DIFF
--- a/articles/virtual-machines/disks-shared.md
+++ b/articles/virtual-machines/disks-shared.md
@@ -169,6 +169,9 @@ The following is an example of a 4-node Linux cluster with a single writer and t
 
 Both shared Ultra Disks and shared Premium SSD v2 managed disks are priced based on provisioned capacity, total provisioned IOPS (diskIOPSReadWrite + diskIOPSReadOnly) and total provisioned Throughput MB/s (diskMB/sReadWrite + diskMB/sReadOnly). There's no extra charge for each additional VM mount. For example, a shared Ultra Disk with the following configuration (diskSizeGB: 1024, DiskIOPSReadWrite: 10000, DiskMB/sReadWrite: 600, DiskIOPSReadOnly: 100, DiskMB/sReadOnly: 1) is charged with 1024 GiB, 10100 IOPS, and 601 MB/s regardless of whether it's mounted to two VMs or five VMs.
 
+>[!CAUTION]
+>Avoid setting the diskIOPSReadOnly value below 100. Lower values may reduce costs but can negatively impact the startup performance of VMs attached to the disk.
+
 ## Next steps
 
 If you're interested in enabling and using shared disks for your managed disks, proceed to our article [Enable shared disk](disks-shared-enable.md)


### PR DESCRIPTION
In a recent support request, setting DiskIOPSReadOnly = 1 caused a boot failure due to read I/O stalling at the UEFI stage.