### PR TITLE
Correct title metadata in update-linux-agent.md

### DIFF
--- a/articles/virtual-machines/extensions/update-linux-agent.md
+++ b/articles/virtual-machines/extensions/update-linux-agent.md
@@ -1,5 +1,5 @@
 ---
-title: Update the Azure Linux Agent from GitHub
+title: How to update the Azure Linux Agent on a VM
 description: Learn how to update Azure Linux Agent for your Linux VM in Azure
 ms.topic: how-to
 ms.service: azure-virtual-machines


### PR DESCRIPTION
This document provides procedures to update Linux Agent.
Now it tells how to obtain update packages from distros' package repositories, however the title in the metadata is still left as "Update the Azure Linux Agent from GitHub."
This PR updates the title in the metadata to fit the latest content.