### PR TITLE
Add warning for Defender AV settings replacement

### DIFF
--- a/articles/virtual-machines/extensions/iaas-antimalware-windows.md
+++ b/articles/virtual-machines/extensions/iaas-antimalware-windows.md
@@ -43,6 +43,8 @@ For more information, see [Set name and type for child resources](/azure/azure-r
 
 The following example assumes the VM extension is nested inside the virtual machine resource. When the extension resource is nested, the JSON is placed in the `"resources": []` object of the virtual machine.
 
+WARNING: Deploying or updating this extension will replace existing Defender AV settings, including exclusions.   
+
 ```json
 {
       "type": "Microsoft.Compute/virtualMachines/extensions",


### PR DESCRIPTION
Added a warning about replacing existing Defender AV settings when deploying or updating the extension.
This is based on customer escalation (strategic customer Mediterranean Shipping) and requested by CXP ACE team.