### PR TITLE
Update container-instances/using-azure-container-registry-mi.md

### DIFF
--- a/articles/container-instances/using-azure-container-registry-mi.md
+++ b/articles/container-instances/using-azure-container-registry-mi.md
@@ -26,6 +26,9 @@ When access to an Azure Container Registry (ACR) is [restricted using a private 
 ## Limitations
 * Windows containers don't support system-assigned managed identity-authenticated image pulls with ACR, only user-assigned.
 
+> [!NOTE]
+> Managed identity access to a private Azure Container Registry can be configured **only** via an ARM/Bicep template or the latest Azure CLI.
+
 ## Configure registry authentication
 
 Your container registry must have Trusted Services enabled. To find instructions on how to enable trusted services, see [Allow trusted services to securely access a network-restricted container registry][allow-access-trusted-services].


### PR DESCRIPTION
Added note about creating managed identity access ACR only possible with ARM template or az cli commands

```
> [!NOTE] 
> Managed identity access to a private Azure Container Registry can be configured only via an ARM/Bicep template or the latest Azure CLI.
```