### PR TITLE
Update azure-hybrid-benefit-linux.md

### DIFF
--- a/articles/virtual-machines/linux/azure-hybrid-benefit-linux.md
+++ b/articles/virtual-machines/linux/azure-hybrid-benefit-linux.md
@@ -487,6 +487,20 @@ Converting to a PAYG subscription model is supported for Azure Marketplace image
     # In order to revert back to the original licensing model, set license-type to None.
     az vm update -g myResourceGroup -n myVmName --license-type NONE
     ```
+In some cases, you must utilize the Azure Management API to patch the license type in the virtual machine's metadata:
+
+1. Define a variable with a full path to the target virtual machine:
+   ```azurecli
+   VM_ID=$(az vm list --query "[?name=='YourVMName'].id" -o tsv)
+   ```
+1. Update the license type by patching the VM's metadata. For example, change PAYG license to SLES_SAP:
+   ```azurecli
+   az rest --method patch --url "https://management.azure.com${VM_ID}?api-version=2024-07-01" --body '{"properties":{"licenseType":"SLES_SAP"}}'
+   ```
+1. If you want to return the original subscription model, set `license-type` to `None`.
+   ```azurecli
+   az rest --method patch --url "https://management.azure.com${VM_ID}?api-version=2024-07-01" --body '{"properties":{"licenseType":"NONE"}}'
+   ```
 
 ---
 

--- a/articles/virtual-machines/linux/azure-hybrid-benefit-linux.md
+++ b/articles/virtual-machines/linux/azure-hybrid-benefit-linux.md
@@ -493,7 +493,7 @@ In some cases, you must utilize the Azure Management API to patch the license ty
    ```azurecli
    VM_ID=$(az vm list --query "[?name=='YourVMName'].id" -o tsv)
    ```
-1. Update the license type by patching the VM's metadata. For example, change PAYG license to SLES_SAP:
+1. Update the license type by patching the VM's metadata. For example, change pay-as-you-go license to SLES_SAP:
    ```azurecli
    az rest --method patch --url "https://management.azure.com${VM_ID}?api-version=2024-07-01" --body '{"properties":{"licenseType":"SLES_SAP"}}'
    ```


### PR DESCRIPTION
Add steps to use API to change VM metadata for SUSE machines- the 'az vm update' commands fail when using them due to the VM's os.profile not being able to be modified.