### PR TITLE
Update limitations section for VM resizing

### DIFF
--- a/articles/virtual-machines/sizes/resize-vm.md
+++ b/articles/virtual-machines/sizes/resize-vm.md
@@ -45,7 +45,7 @@ For more information on choosing the right SKU, you can use the following resour
 
 ## Limitations
 
-1. Resize between a VM size that has a local temp disk to a VM size with no local temp disk and vice versa is supported for Linux VMs. For Windows, the only combinations allowed for resizing are:
+1. Resizing between VM sizes that have a local temp disk and VM sizes that have no local temp disk is supported for Linux VMs. For Windows VMs, only the following resize combinations are allowed:
 
 - VM (with local temp disk) -> VM (with local temp disk); and
 - VM (with no local temp disk) -> VM (with no local temp disk).

--- a/articles/virtual-machines/sizes/resize-vm.md
+++ b/articles/virtual-machines/sizes/resize-vm.md
@@ -45,9 +45,7 @@ For more information on choosing the right SKU, you can use the following resour
 
 ## Limitations
 
-1. You can't resize a VM size that has a local temp disk to a VM size with no local temp disk and vice versa.
-
-   The only combinations allowed for resizing are:
+1. Resize between a VM size that has a local temp disk to a VM size with no local temp disk and vice versa is supported for Linux VMs. For Windows, the only combinations allowed for resizing are:
 
 - VM (with local temp disk) -> VM (with local temp disk); and
 - VM (with no local temp disk) -> VM (with no local temp disk).


### PR DESCRIPTION
Clarified limitations on resizing VMs regarding local temp disks, specifying support for Linux VMs and allowed combinations for Windows VMs. Linux machines support this resize, which was tested in a repro and is also confirmed in this article: https://learn.microsoft.com/en-us/azure/virtual-machines/azure-vms-no-temp-disk#can-i-resize-a-vm-size-that-has-a-local-temp-disk-to-a-vm-size-with-no-local-temp-disk---

The previous documentation was inducing error and also allowing Copilot to provide wrong answers.