### PR TITLE
Update diagnostic settings example in documentation

### DIFF
--- a/articles/container-instances/monitor-azure-container-instances-reference.md
+++ b/articles/container-instances/monitor-azure-container-instances-reference.md
@@ -104,7 +104,7 @@ For example, here's how you can use `New-AzDiagnosticSetting` command to apply a
 
 ```azurepowershell
 $log = @()
-$log += New-AzDiagnosticSettingLogSettingsObject -Enabled $true -Category ContainerInstanceLog -RetentionPolicyDay 7 -RetentionPolicyEnabled $true
+$log += New-AzDiagnosticSettingLogSettingsObject -Enabled $true -Category ContainerInstanceLog
  
 New-AzDiagnosticSetting -Name test-setting -ResourceId <container-group-resource-id> -WorkspaceId <log-analytics-workspace-id> -Log $log
 ```


### PR DESCRIPTION
Removed retention policy Enabling option from diagnostic settings log object.
Confirmed this option does not work.