### PR TITLE
Add missing parameters for container creation command

### DIFF
--- a/articles/container-instances/container-instances-vnet.md
+++ b/articles/container-instances/container-instances-vnet.md
@@ -98,6 +98,9 @@ az container create \
   --name $MY_APP_CONTAINER_NAME \
   --resource-group $MY_RESOURCE_GROUP_NAME \
   --image mcr.microsoft.com/azuredocs/aci-helloworld \
+  --os-type Linux \
+  --cpu 1 \
+  --memory 1.5 \
   --vnet $MY_VNET_NAME \
   --vnet-address-prefix 10.0.0.0/16 \
   --subnet $MY_SUBNET_NAME \


### PR DESCRIPTION
with current Azure CLI / API versions, this fails because:

--os-type is not explicitly specified
→ Results in
(InvalidOsType) The 'osType' for container group '<null>' is invalid.

CPU & memory requests are not explicitly specified → Results in
(ResourceRequestsNotSpecified)
Both memory and CPU requests are required.

Current ACI API requirements
The YAML example in the same document
The successful output shown later (osType: Linux, cpu: 1.0, memoryInGb: 1.5)

Azure CLI example fails because --os-type, --cpu, and --memory are missing