### PR TITLE
Reorganize instance size flexibility information

### DIFF
--- a/articles/virtual-machines/reserved-vm-instance-size-flexibility.md
+++ b/articles/virtual-machines/reserved-vm-instance-size-flexibility.md
@@ -41,12 +41,11 @@ The following sections show what sizes are in the same size series group when yo
 
 ## Instance size flexibility ratio
 
-You also use API or PowerShell to fetch the ratios. The CSV link and schema are kept up to date so you can use them programmatically. Read more [here](/azure/cost-management-billing/reservations/instance-size-flexibility).
-
 CSV below has the instance size flexibility groups, ArmSkuName and the ratios. 
 
-
 [Instance size flexibility ratios](https://aka.ms/isf)
+
+You can also use API or PowerShell to fetch the ratios. The CSV link and schema are kept up to date so you can use them programmatically. Read more [here](/azure/cost-management-billing/reservations/instance-size-flexibility).
 
 > [!CAUTION]
  > Beginning May 9, 2026, the CSV file will no longer receive updates and will be removed on August 30, 2026, in favor of accessing data through the API or PowerShell. Read more [here](/azure/cost-management-billing/reservations/instance-size-flexibility).


### PR DESCRIPTION
Reordered the paragraph about fetching instance size flexibility ratios and replaced "You also use.." with "You can also use.." for clarity. 

This is very small change, so submitting it via the browser edit option. Thank you.