### PR TITLE
Fix formatting for nca100v4 example workloads

### DIFF
--- a/articles/virtual-machines/sizes/gpu-accelerated/includes/nca100v4-series-summary.md
+++ b/articles/virtual-machines/sizes/gpu-accelerated/includes/nca100v4-series-summary.md
@@ -13,10 +13,10 @@ ms.custom: include file
 ---
 The NC A100 v4 series virtual machine (VM) is a new addition to the Azure GPU family. You can use this series for real-world Azure Applied AI training and batch inference workloads. The NC A100 v4 series is powered by NVIDIA A100 PCIe GPU and third generation AMD EPYC™ 7V13 (Milan) processors. The VMs feature up to 4 NVIDIA A100 PCIe GPUs with 80 GB memory each, up to 96 non-multithreaded AMD EPYC Milan processor cores and 880 GiB of system memory. These VMs are ideal for real-world Applied AI workloads, such as:
 
-GPU-accelerated analytics and databases
-Batch inferencing with heavy pre- and post-processing
-Autonomy model training
-Oil and gas reservoir simulation
-Machine learning (ML) development
-Video processing
-AI/ML web services
+- GPU-accelerated analytics and databases
+- Batch inferencing with heavy pre- and post-processing
+- Autonomy model training
+- Oil and gas reservoir simulation
+- Machine learning (ML) development
+- Video processing
+- AI/ML web services


### PR DESCRIPTION
The list of example workloads for [NC_A100_V4](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/nca100v4-series?tabs=sizebasic) is smushed together instead of shown as a list:
<img width="892" height="356" alt="image" src="https://github.com/user-attachments/assets/68a397d1-788f-4401-8efa-bbde6702b56c" />

Adjust the list to max the bulleted style for other SKUs (e.g. [NCv6](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/nc-rtxpro6000-bse-v6-series?tabs=sizebasicgp%2Csizebasicco)).