### PR TITLE
Fix front-end bandwidth unit: Mbps → Gbps in ND GB200-v6 and ND GB300-v6 series

### DIFF
--- a/articles/virtual-machines/sizes/gpu-accelerated/nd-gb200-v6-series.md
+++ b/articles/virtual-machines/sizes/gpu-accelerated/nd-gb200-v6-series.md
@@ -78,7 +78,7 @@ Remote (uncached) storage info for each size
 
 Network interface info for each size
 
-| Size Name | Max Front-end NICs (Qty.) | Max Front-end Bandwidth (Mbps) | Max Scale-up NICS (Qty.) | Max Scale-Up Bandwidth (Gbps)<sup>1</sup> | Max Scale-out NICS (Qty.) | Max Scale-Out Bandwidth (TBps)<sup>2</sup> |
+| Size Name | Max Front-end NICs (Qty.) | Max Front-end Bandwidth (Gbps) | Max Scale-up NICS (Qty.) | Max Scale-Up Bandwidth (Gbps)<sup>1</sup> | Max Scale-out NICS (Qty.) | Max Scale-Out Bandwidth (TBps)<sup>2</sup> |
 | --- | --- | --- | --- | --- | --- | --- |
 | Standard_ND128isr_NDR_GB200_v6 | 1 | 160 | 4 | 400 | 4 | 1.8 |
 

--- a/articles/virtual-machines/sizes/gpu-accelerated/nd-gb300-v6-series.md
+++ b/articles/virtual-machines/sizes/gpu-accelerated/nd-gb300-v6-series.md
@@ -78,7 +78,7 @@ Remote (uncached) storage info for each size
 
 Network interface info for each size
 
-| Size Name | Max Front-end NICs (Qty.) | Max Front-end Bandwidth (Mbps) | Max Scale-up NICS (Qty.) | Max Scale-Up Bandwidth (TBps)<sup>1</sup> | Max Scale-out NICS (Qty.) | Max Scale-Out Bandwidth (Gbps)<sup>2</sup> |
+| Size Name | Max Front-end NICs (Qty.) | Max Front-end Bandwidth (Gbps) | Max Scale-up NICS (Qty.) | Max Scale-Up Bandwidth (TBps)<sup>1</sup> | Max Scale-out NICS (Qty.) | Max Scale-Out Bandwidth (Gbps)<sup>2</sup> |
 | --- | --- | --- | --- | --- | --- | --- |
 | Standard_ND128isr_GB300_v6 | 1 | 160 | 4 | 1.8 | 4 | 4x800 |
 


### PR DESCRIPTION
## Summary

The Network spec tables in `nd-gb300-v6-series.md` and `nd-gb200-v6-series.md` label the front-end bandwidth column as `Max Front-end Bandwidth (Mbps)` with a value of `160`. The unit is incorrect — it should be **Gbps**.

## Why

- Within the same table, Scale-Up bandwidth is shown in `Gbps`/`TBps` and Scale-Out in `Gbps`/`TBps`. A front-end NIC at 160 Mbps (~0.005% of the scale-out fabric) is internally inconsistent for this class of HPC/GPU VM.
- Azure's [Virtual machine network bandwidth](https://learn.microsoft.com/azure/virtual-network/virtual-machine-network-throughput) documentation reports front-end bandwidth in Gbps for comparable ND-series SKUs.
- The renderered page on Microsoft Learn currently shows the same misleading unit:
  - https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/nd-gb300-v6-series?tabs=sizenetwork
  - https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/nd-gb200-v6-series?tabs=sizenetwork

## Change

Column header only; values are unchanged.

| File | Before | After |
| --- | --- | --- |
| `nd-gb300-v6-series.md` | `Max Front-end Bandwidth (Mbps)` | `Max Front-end Bandwidth (Gbps)` |
| `nd-gb200-v6-series.md` | `Max Front-end Bandwidth (Mbps)` | `Max Front-end Bandwidth (Gbps)` |

If the intended bandwidth for this VM family is something other than 160 Gbps, please advise and I can adjust the value as well.
