### PR TITLE
Incorrect unit for network BW

### DIFF
--- a/articles/virtual-machines/sizes/gpu-accelerated/nd-gb300-v6-series.md
+++ b/articles/virtual-machines/sizes/gpu-accelerated/nd-gb300-v6-series.md
@@ -78,7 +78,7 @@ Remote (uncached) storage info for each size
 
 Network interface info for each size
 
-| Size Name | Max Front-end NICs (Qty.) | Max Front-end Bandwidth (Mbps) | Max Scale-up NICS (Qty.) | Max Scale-Up Bandwidth (TBps)<sup>1</sup> | Max Scale-out NICS (Qty.) | Max Scale-Out Bandwidth (Gbps)<sup>2</sup> |
+| Size Name | Max Front-end NICs (Qty.) | Max Front-end Bandwidth (Gbps) | Max Scale-up NICS (Qty.) | Max Scale-Up Bandwidth (TBps)<sup>1</sup> | Max Scale-out NICS (Qty.) | Max Scale-Out Bandwidth (Gbps)<sup>2</sup> |
 | --- | --- | --- | --- | --- | --- | --- |
 | Standard_ND128isr_GB300_v6 | 1 | 160 | 4 | 1.8 | 4 | 4x800 |
 


### PR DESCRIPTION
Incorrect unit for network BW. It should be 160Gbps, instead of 160Mbps