### PR TITLE
Incorrect unit for network BW

### DIFF
--- a/articles/virtual-machines/sizes/gpu-accelerated/nd-gb200-v6-series.md
+++ b/articles/virtual-machines/sizes/gpu-accelerated/nd-gb200-v6-series.md
@@ -78,7 +78,7 @@ Remote (uncached) storage info for each size
 
 Network interface info for each size
 
-| Size Name | Max Front-end NICs (Qty.) | Max Front-end Bandwidth (Mbps) | Max Scale-up NICS (Qty.) | Max Scale-Up Bandwidth (Gbps)<sup>1</sup> | Max Scale-out NICS (Qty.) | Max Scale-Out Bandwidth (TBps)<sup>2</sup> |
+| Size Name | Max Front-end NICs (Qty.) | Max Front-end Bandwidth (Gbps) | Max Scale-up NICS (Qty.) | Max Scale-Up Bandwidth (Gbps)<sup>1</sup> | Max Scale-out NICS (Qty.) | Max Scale-Out Bandwidth (TBps)<sup>2</sup> |
 | --- | --- | --- | --- | --- | --- | --- |
 | Standard_ND128isr_NDR_GB200_v6 | 1 | 160 | 4 | 400 | 4 | 1.8 |
 


### PR DESCRIPTION
Incorrect unit for network BW. It should be 160Gbps, instead of 160Mbps