### PR TITLE
Add NVadsV710v5-series to hibernation support list

### DIFF
--- a/articles/virtual-machines/hibernate-resume.md
+++ b/articles/virtual-machines/hibernate-resume.md
@@ -55,6 +55,7 @@ VM sizes with up to 64-GB RAM from the following General Purpose VM series suppo
 VM sizes with up to 112-GB RAM from the following GPU VM series support hibernation.
 - [NVv4-series](../virtual-machines/nvv4-series.md)
 - [NVadsA10v5-series](../virtual-machines/nva10v5-series.md)
+- [NVadsV710v5-series](../virtual-machines/nvadsv710-v5-series.md)
 
 If you are using any UVM-enabled compute applications, we recommend idling the application before initiating hibernation. 
 


### PR DESCRIPTION
It has been noticed that NVads V710 v5 series also support hibernation but it is not mentioned in the supported VM lists for hibernation.