### PR TITLE
Update Ultra Disk regional and zonal availability table

### DIFF
--- a/articles/virtual-machines/includes/managed-disks-ultra-disks-ga-scope-and-limitations.md
+++ b/articles/virtual-machines/includes/managed-disks-ultra-disks-ga-scope-and-limitations.md
@@ -26,10 +26,10 @@ The following table outlines the regions Ultra Disks are available in, and their
 
 | Redundancy options | Regions |
 |--------------------|---------|
-| **Regional** | Australia Central, Australia Central 2<br/>Brazil Southeast<br/>Canada East<br/>Korea South<br/>Norway West<br/>UK West<br/>North Central US, West US<br/>US Gov Arizona, US Gov Texas |
-| **One availability zone** | Brazil South<br/>Central India<br/>East Asia<br/>Germany West Central<br/>Japan West<br/>Korea Central<br/>South Central US<br/>Spain Central<br/>US Gov Virginia |
-| **Two availability zones** | Indonesia Central<br/>Malaysia West<br/>New Zealand North<br/>Qatar Central |
-| **Three availability zones** | Australia East<br/>Canada Central<br/>China North 3<br/>North Europe, West Europe<br/>France Central<br/>Italy North<br/>Japan East<br/>Poland Central<br/>South Africa North<br/>Southeast Asia<br/>Sweden Central<br/>Switzerland North<br/>UAE North<br/>UK South<br/>Central US, East US, East US 2, West US 2, West US 3 |
+| **Regional** | Australia Central<br/>Australia Central 2<br/>Brazil Southeast<br/>Canada East<br/>Korea South<br/>North Central US<br/>Norway West<br/>Taiwan North<br/>UK West<br/>US Gov Arizona<br/>US Gov Texas<br/>West US |
+| **One availability zone** | Brazil South<br/>Central India<br/>East Asia<br/>Korea Central<br/>US Gov Virginia |
+| **Two availability zones** | Germany West Central<br/>Japan West<br/>Qatar Central<br/>South Central US<br/>Spain Central |
+| **Three availability zones** | Australia East<br/>Austria East<br/>Canada Central<br/>Central US<br/>China North 3<br/>East US<br/>East US 2<br/>France Central<br/>Indonesia Central<br/>Italy North<br/>Japan East<br/>Malaysia West<br/>New Zealand North<br/>North Europe<br/>Poland Central<br/>South Africa North<br/>Southeast Asia<br/>Sweden Central<br/>Switzerland North<br/>UAE North<br/>UK South<br/>West Europe<br/>West US 2<br/>West US 3 |
 
 Not every VM size is available in every supported region with Ultra Disks. The following table lists VM series that are compatible with Ultra Disks.
 


### PR DESCRIPTION
- Add Taiwan North as Regional
- Add Austria East to 3 AZs
- Move Indonesia Central, Malaysia West, New Zealand North from 2 AZs to 3 AZs
- Move Germany West Central, Japan West, South Central US, Spain Central from 1 AZ to 2 AZs
- Alphabetize all regions within each category
- List each region individually (one per line)
- Total regions: 46 (previously 44)