### PR TITLE
Remove Uniform VMSS-specific notes from Ultra Disk docs

### DIFF
--- a/articles/virtual-machines/disks-types.md
+++ b/articles/virtual-machines/disks-types.md
@@ -61,18 +61,16 @@ The following table provides an example of performance caps an Ultra Disk has de
 
 |Disk Size (GiB)  |IOPS Cap  |Throughput Cap (MB/s)  |
 |---------|---------|---------|
-|4     |4,000 (1,200)*          |1,000 (300)*         |
-|8     |8,000 (2,400)*          |2,000 (600)*          |
-|16     |16,000 (4,800)*        |4,000 (1,200)*          |
-|32     |32,000 (9,600)*         |8,000 (2,400)*          |
-|64     |64,000 (19,200)*         |10,000 (4,900)*          |
-|128     |128,000 (38,400)*         |10,000 (9,800)*          |
-|256     |256,000 (76,000)*         |10,000         |
-|512     |400,000 (153,000)*         |10,000         |
-|1,024    |400,000 (307,200)*        |10,000        |
+|4     |4,000          |1,000          |
+|8     |8,000          |2,000          |
+|16     |16,000        |4,000          |
+|32     |32,000         |8,000          |
+|64     |64,000         |10,000          |
+|128     |128,000         |10,000          |
+|256     |256,000         |10,000         |
+|512     |400,000         |10,000         |
+|1,024    |400,000        |10,000        |
 |2,048-65,536|400,000         |10,000         |
-
-\* Only applies during deployment of Virtual Machine Scale Sets with Uniform orchestration mode. Setting a higher value during deployment results in a failed deployment. After deployment completes you can [increase the performance](disks-enable-ultra-ssd.md#adjust-the-performance-of-an-ultra-disk) of your disks.
 
 
 ### Ultra Disk performance
@@ -83,17 +81,11 @@ Ultra Disks are designed to provide consistently low sub millisecond latencies a
 
 Ultra Disks support IOPS limits of 1000 IOPS/GiB, up to a maximum of 400,000 IOPS per disk. To achieve the target IOPS for the disk, ensure that the selected disk IOPS are less than the VM IOPS limit. Ultra Disks with greater IOPS can be used as shared disks to support multiple VMs. The minimum baseline IOPS per disk is 100.
 
-> [!NOTE]
-> Only during deployment of Ultra Disks while using Uniform Virtual Machine Scale Sets: The minimum IOPS per disk are 1 IOPS/GiB, with an overall baseline minimum of 100 IOPS. The maximum IOPS per disk are 300 IOPS/GiB, up to a maximum of 400,000 IOPS per disk. If you exceed these limits at deployment, the deployment fails. You can [increase the performance](disks-enable-ultra-ssd.md#adjust-the-performance-of-an-ultra-disk) of these disks once deployment completes.
-
 For more information about IOPS, see [Virtual machine and disk performance](disks-performance.md).
 
 ### Ultra Disk throughput
 
 The maximum throughput limit of an Ultra Disk is .25 MB/s for each provisioned IOPS, up to a maximum of 10,000 MB/s per disk (where MB/s = 10^6 Bytes per second). The minimum guaranteed throughput of an Ultra Disk is 1 MB/s.
-
-> [!NOTE]
-> Only during deployment of Ultra Disks while using Uniform Virtual Machine Scale Sets: The minimum throughput of an Ultra Disk is 4-KB/s per provisioned IOPS. So if you provision a 500 GiB, 500 IOPS Ultra Disk, the minimum throughput for that disk would be 2 MB/s and the maximum throughput that can be provisioned is 125 MB/s.
 
 You can adjust Ultra Disk IOPS and throughput performance at runtime without detaching the disk from the virtual machine. After a performance resize operation has been issued on a disk, it can take up to an hour for the change to take effect. Up to four performance resize operations are permitted during a 24-hour window.
 

--- a/articles/virtual-machines/includes/managed-disks-ultra-disks-ga-scope-and-limitations.md
+++ b/articles/virtual-machines/includes/managed-disks-ultra-disks-ga-scope-and-limitations.md
@@ -11,7 +11,6 @@ ms.custom: include file
 ---
 
 The following list contains Ultra Disk's limitations:
-- Only during deployment with Virtual Machine Scale Sets with Uniform orchestration mode: At time of deployment, Ultra Disks used with Uniform Virtual Machine Scale Sets use different formulas for IOPS and throughput for their performance. Exceeding the limits of these formulas results in a deployment failure. Once the deployment succeeds you can [increase the performance](../disks-enable-ultra-ssd.md#adjust-the-performance-of-an-ultra-disk) of these disks. See [Ultra Disk IOPS](../disks-types.md#ultra-disk-iops) and [Ultra Disk throughput](../disks-types.md#ultra-disk-throughput) for details. 
 - Ultra Disks can't be used as an OS disk or with Azure Compute Gallery.
 - Currently, Ultra Disks only support Single VM and Availability zone infrastructure options as locally redundant storage (LRS). Ultra Disks don't support zone redundant storage (ZRS).
 - Ultra Disks don't support availability sets.


### PR DESCRIPTION
Remove all references to Uniform orchestration mode limitations:
- Remove parenthetical Uniform VMSS caps from size table
- Remove asterisk footnote about Uniform deployment limits
- Remove IOPS NOTE box about Uniform VMSS limits
- Remove throughput NOTE box about Uniform VMSS limits
- Remove Uniform VMSS bullet from limitations include file