### PR TITLE
Change Accelerated Networking requirement to 'Required'

### DIFF
--- a/articles/virtual-machines/sizes/memory-optimized/edv5-series.md
+++ b/articles/virtual-machines/sizes/memory-optimized/edv5-series.md
@@ -146,7 +146,7 @@ Accelerator (GPUs, FPGAs, etc.) info for each size
 |[Memory Preserving Updates](../../maintenance-and-updates.md)| Supported |
 |[Generation 2 VMs](../../generation-2.md)| Supported |
 |[Generation 1 VMs](../../generation-2.md)| Supported |
-|[Accelerated Networking](/azure/virtual-network/create-vm-accelerated-networking-cli)| Supported |
+|[Accelerated Networking](/azure/virtual-network/create-vm-accelerated-networking-cli)| Required |
 |[Ephemeral OS Disk](../../ephemeral-os-disks.md)| Supported |
 |[Local temporary storage](../../overview.md#local-temporary-storage)| Supported |
 |[Nested Virtualization](/virtualization/hyper-v-on-windows/user-guide/nested-virtualization)| Supported |


### PR DESCRIPTION
Fix: The Edv5 series actually requires Accelarated Networking, so this has been updated.