### PR TITLE
Correct minimum IOPS required to reach 2,000 MB/s Pv2 throughput

### DIFF
--- a/articles/virtual-machines/disks-types.md
+++ b/articles/virtual-machines/disks-types.md
@@ -134,7 +134,7 @@ All Premium SSD v2 disks have a baseline IOPS of 3,000 that is free of charge. A
 
 #### Premium SSD v2 throughput
 
-All Premium SSD v2 disks have a baseline throughput of 125 MB/s that is free of charge. After 6 GiB, the maximum throughput that can be set increases by 0.25 MB/s per set IOPS. If a disk has 3,000 IOPS, the max throughput it can set is 750 MB/s. To raise the throughput for this disk beyond 750 MB/s, its IOPS must be increased. For example, if you increased the IOPS to 4,000, then the max throughput that can be set is 1,000 MB/s. 2,000 MB/s is the maximum throughput supported for disks that have 5,000 IOPS or more. Increasing your throughput beyond 125 MB/s increases the price of your disk.
+All Premium SSD v2 disks have a baseline throughput of 125 MB/s that is free of charge. After 6 GiB, the maximum throughput that can be set increases by 0.25 MB/s per set IOPS. If a disk has 3,000 IOPS, the max throughput it can set is 750 MB/s. To raise the throughput for this disk beyond 750 MB/s, its IOPS must be increased. For example, if you increased the IOPS to 4,000, then the max throughput that can be set is 1,000 MB/s. 2,000 MB/s is the maximum throughput supported for disks that have 8,000 IOPS or more. Increasing your throughput beyond 125 MB/s increases the price of your disk.
 
 #### Premium SSD v2 Sector Sizes
 Premium SSD v2 supports a 4k physical sector size by default. A 512E sector size is also supported. While most applications are compatible with 4k sector sizes, some require 512-byte sector sizes. Oracle Database, for example, requires release 12.2 or later in order to support 4k native disks.


### PR DESCRIPTION
Currently [Premium SSD v2 throughput](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#premium-ssd-v2-throughput) states that:

>  2,000 MB/s is the maximum throughput supported for disks that have 5,000 IOPS or more.

It mostly made sense when the max throughput was 1,200 MB/s.
However, after the throughput was changed to 2,000 MB/s (in https://github.com/MicrosoftDocs/azure-compute-docs/commit/b1fc07b7dc32e36f18a9bc06d30312b280919399), the same number of IOPS is not valid anymore (also confirmed via Azure CLI with Cloud Shell).
This pull request sets the correct number of IOPS.