### PR TITLE
Update disk-encryption-migrate.md

### DIFF
--- a/articles/virtual-machines/disk-encryption-migrate.md
+++ b/articles/virtual-machines/disk-encryption-migrate.md
@@ -113,9 +113,9 @@ sourceDiskSizeBytes=$(az disk show -g $sourceRG -n $sourceDiskName --query '[dis
 az disk create -g $targetRG -n $targetDiskName -l $targetLocation --os-type $targetOS --for-upload --upload-size-bytes $(($sourceDiskSizeBytes+512)) --sku standard_lrs
 
 # Generate SAS URIs for both disks
-targetSASURI=$(az disk grant-access -n $targetDiskName -g $targetRG --access-level Write --duration-in-seconds 86400 --query [accessSas] -o tsv)
+targetSASURI=$(az disk grant-access -n $targetDiskName -g $targetRG --access-level Write --duration-in-seconds 86400 --query [accessSAS] -o tsv)
 
-sourceSASURI=$(az disk grant-access -n $sourceDiskName -g $sourceRG --access-level Read --duration-in-seconds 86400 --query [accessSas] -o tsv)
+sourceSASURI=$(az disk grant-access -n $sourceDiskName -g $sourceRG --access-level Read --duration-in-seconds 86400 --query [accessSAS] -o tsv)
 
 # Copy the disk data using AzCopy
 azcopy copy $sourceSASURI $targetSASURI --blob-type PageBlob


### PR DESCRIPTION
Issue: CLI script used while generating new Managed disk in MDE to HBE migration document is not working due to Syntax error in SAS token generation step.
•	Issue observed during disk copy using AzCopy where command failed with “wrong number of arguments”
•	On initial validation, identified that $sourceSASURI and $targetSASURI variables were empty
•	Confirmed by echoing variables and seeing no values populated
=================================================
targetSASURI=$(az disk grant-access -n $targetDiskName -g $targetRG --access-level Write --duration-in-seconds 86400 --query [accessSas] -o tsv)
rakesh [ ~ ]$ sourceSASURI=$(az disk grant-access -n $sourceDiskName -g $sourceRG --access-level Read --duration-in-seconds 86400 --query [accessSas] -o tsv)
rakesh [ ~ ]$ echo $sourceSASURI 
None
rakesh [ ~ ]$ echo $targetSASURI 
None
=================================================

•	Root cause identified as case-sensitivity issue in Azure CLI query
•	Script was using --query accessSas, while actual field returned by CLI is accessSAS (case-sensitive mismatch) when tried to generate the SAS manually.
=======================================
az disk grant-access -n $targetDiskName -g $targetRG --access-level Write --duration-in-seconds 86400
{
  "accessSAS": "https://md-impexp-xxxxxxxxx.z5.blob.storage.azure.net/qfc0cr0jtq2s/abcd?sv=xxxx-03-28&sr=b&si=a76a778d-42b6-4225-ae51-cee4054a5442&sig=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx%3D"
}
========================================

•	Due to incorrect case, SAS values were not captured into variables, leading to empty inputs for AzCopy
•	Notably, PowerShell flow worked as expected, as it handles the response object directly without requiring explicit field name matching
•	However, when using Azure CLI (bash script) to create disk and copy data, SAS generation appeared to fail due to incorrect query casing
•	Updated query to use --query accessSAS, after which SAS URLs were correctly retrieved
=======================================================
targetSASURI=$(az disk grant-access -n $targetDiskName -g $targetRG --access-level Write --duration-in-seconds 86400 --query [accessSAS] -o tsv)
rakesh [ ~ ]$ sourceSASURI=$(az disk grant-access -n $sourceDiskName -g $sourceRG --access-level Read --duration-in-seconds 86400 --query [accessSAS] -o tsv)
rakesh [ ~ ]$ echo $targetSASURI 
https://md-impexp-xxxxxxxxxxxxxxxxxxxxxxjvk.z5.blob.storage.azure.net/qfc0cr0jtq2s/abcd?sv=2018-03-28&sr=b&si=a76a778d-42b6-4225-ae51-cee4054a5442xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx0%3D
rakesh [ ~ ]$ echo $sourceSASURI 
https://md-hdd-xxxxxxxxxxxxxxx.blob.storage.azure.net/qcs35zbrcl3t/abcd?sv=2018-03-28&sr=b&si=2a8fdd6f-b9ec-48e9-9947-031d07e62xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxc%3D
=======================================================
•	Post fix, variables were populated successfully and AzCopy command completed without issues


