### PR TITLE
Clarify NVMe handling in Service Fabric extension docs

### DIFF
--- a/articles/service-fabric/service-fabric-cluster-nodetypes.md
+++ b/articles/service-fabric/service-fabric-cluster-nodetypes.md
@@ -56,8 +56,6 @@ The following is a snippet of Service Fabric **Windows** Virtual Machine extensi
          "clusterEndpoint": "[reference(parameters('clusterName')).clusterEndpoint]",
          "nodeTypeRef": "[variables('vmNodeType0Name')]",
          "durabilityLevel": "Silver",
-         "enableParallelJobs": true,
-         "nicPrefixOverride": "[variables('subnet0Prefix')]",
          "dataPath": "D:\\\\SvcFab",
          "certificate": {
            "commonNames": [
@@ -89,8 +87,6 @@ The following is a snippet of Service Fabric **Linux** Virtual Machine extension
          "clusterEndpoint": "[reference(parameters('clusterName')).clusterEndpoint]",
          "nodeTypeRef": "[variables('vmNodeType0Name')]",
          "durabilityLevel": "Silver",
-         "enableParallelJobs": true,
-         "nicPrefixOverride": "[variables('subnet0Prefix')]",
          "certificate": {
            "commonNames": [
               "[parameters('certificateCommonName')]"
@@ -118,7 +114,7 @@ The following are the property descriptions:
 | nicPrefixOverride | string | Subnet Prefix like "10.0.0.0/24" |
 | commonNames | string[] | Common Names of installed cluster certificates |
 | x509StoreName | string | Name of Store where installed cluster certificate is located |
-| typeHandlerVersion | 1.1 (Windows) or 2.0 (Linux) | Version of Extension. 1.0 classic versions of extension are recommended to upgrade to 1.1 |
+| typeHandlerVersion | 1.1 (Windows) or 2.0 (Linux) | Version of extension. Upgrade is required: older versions are no longer supported. For Linux, use 2.0 with `enableAutomaticUpgrade` set to `true`. |
 | dataPath | string | Path to the drive used to save state for Service Fabric system services and application data.
 
 ## Next steps

--- a/articles/service-fabric/service-fabric-cluster-nodetypes.md
+++ b/articles/service-fabric/service-fabric-cluster-nodetypes.md
@@ -6,6 +6,7 @@ ms.author: tomcassidy
 author: tomvcassidy
 ms.service: azure-service-fabric
 services: service-fabric
+ai-usage: ai-assisted
 ms.date: 03/22/2026
 ms.update-cycle: 1095-days
 # Customer intent: As an application architect, I want to understand how Azure Service Fabric node types interact with virtual machine scale sets, so that I can effectively design and manage my cloud infrastructure for optimal performance and scalability.
@@ -37,20 +38,20 @@ If you deployed your cluster in the Azure portal or used the sample Azure Resour
 
 Service Fabric Virtual Machine Extension is used to bootstrap Service Fabric to Azure Virtual Machines, and configure the Node Security.
 
-The following is a snippet of Service Fabric Virtual Machine extension:
+The following is a snippet of Service Fabric **Windows** Virtual Machine extension:
 
 ```json
 "extensions": [
   {
     "name": "[concat('ServiceFabricNodeVmExt','_vmNodeType0Name')]",
     "properties": {
-      "type": "ServiceFabricLinuxNode",
+      "publisher": "Microsoft.Azure.ServiceFabric",
+      "type": "ServiceFabricNode",
+      "typeHandlerVersion": "1.1",
       "autoUpgradeMinorVersion": true,
-      "enableAutomaticUpgrade": true,
       "protectedSettings": {
         "StorageAccountKey1": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key1]",
        },
-       "publisher": "Microsoft.Azure.ServiceFabric",
        "settings": {
          "clusterEndpoint": "[reference(parameters('clusterName')).clusterEndpoint]",
          "nodeTypeRef": "[variables('vmNodeType0Name')]",
@@ -64,8 +65,39 @@ The following is a snippet of Service Fabric Virtual Machine extension:
            ],
            "x509StoreName": "[parameters('certificateStoreValue')]"
          }
+       }
+     }
+   },
+```
+
+The following is a snippet of Service Fabric **Linux** Virtual Machine extension:
+
+```json
+"extensions": [
+  {
+    "name": "[concat('ServiceFabricNodeVmExt','_vmNodeType0Name')]",
+    "properties": {
+      "publisher": "Microsoft.Azure.ServiceFabric",
+      "type": "ServiceFabricLinuxNode",
+      "autoUpgradeMinorVersion": true,
+      "enableAutomaticUpgrade": true,
+      "typeHandlerVersion": "2.0",
+      "protectedSettings": {
+        "StorageAccountKey1": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')),'2015-05-01-preview').key1]",
        },
-       "typeHandlerVersion": "2.0"
+       "settings": {
+         "clusterEndpoint": "[reference(parameters('clusterName')).clusterEndpoint]",
+         "nodeTypeRef": "[variables('vmNodeType0Name')]",
+         "durabilityLevel": "Silver",
+         "enableParallelJobs": true,
+         "nicPrefixOverride": "[variables('subnet0Prefix')]",
+         "certificate": {
+           "commonNames": [
+              "[parameters('certificateCommonName')]"
+           ],
+           "x509StoreName": "[parameters('certificateStoreValue')]"
+         }
+       }
      }
    },
 ```
@@ -86,7 +118,7 @@ The following are the property descriptions:
 | nicPrefixOverride | string | Subnet Prefix like "10.0.0.0/24" |
 | commonNames | string[] | Common Names of installed cluster certificates |
 | x509StoreName | string | Name of Store where installed cluster certificate is located |
-| typeHandlerVersion | 1.1 (ServiceFabricNode), 2.0 (ServiceFabricLinuxNode) | Version of Extension. |
+| typeHandlerVersion | 1.1 (Windows) or 2.0 (Linux) | Version of Extension. 1.0 classic versions of extension are recommended to upgrade to 1.1 |
 | dataPath | string | Path to the drive used to save state for Service Fabric system services and application data.
 
 ## Next steps

--- a/articles/service-fabric/service-fabric-managed-disk.md
+++ b/articles/service-fabric/service-fabric-managed-disk.md
@@ -6,6 +6,7 @@ ms.author: tomcassidy
 author: tomvcassidy
 ms.service: azure-service-fabric
 services: service-fabric
+ai-usage: ai-assisted
 ms.date: 03/22/2026
 # Customer intent: As a cloud architect, I want to configure Azure Service Fabric node types with managed data disks, so that I can ensure persistent and scalable data storage for my applications.
 ---
@@ -15,6 +16,11 @@ ms.date: 03/22/2026
 Azure Service Fabric node types, by default, use the temporary disk on each virtual machine (VM) in the underlying virtual machine scale set for data storage. However, because the temporary disk isn't persistent, and the size of the temporary disk is bound to a given VM SKU, this can be too restrictive for some scenarios. 
 
 This article provides the steps for how to use native support from Service Fabric to configure and use managed data disks as the default data path. Service Fabric will automatically configure managed data disks at node type creation and handle situations where VMs or the virtual machine scale set is reimaged.
+
+> [!IMPORTANT]
+> Service Fabric managed data disk support doesn't initialize NVMe disks on VM SKUs that use NVMe-based storage (for example, v6 and newer SKUs). For these SKUs, initialize and format the managed disk yourself by using a Custom Script Extension.
+>
+> If you use the temporary disk for `dataPath` and the VM SKU uses an NVMe temporary disk, you must also initialize and format that disk yourself. For more information, see [Enable NVMe interface on your VMs and VM scale sets (FAQ)](https://learn.microsoft.com/en-us/azure/virtual-machines/enable-nvme-temp-faqs).
 
 ## Prerequisites
 

--- a/articles/service-fabric/service-fabric-managed-disk.md
+++ b/articles/service-fabric/service-fabric-managed-disk.md
@@ -18,9 +18,13 @@ Azure Service Fabric node types, by default, use the temporary disk on each virt
 This article provides the steps for how to use native support from Service Fabric to configure and use managed data disks as the default data path. Service Fabric will automatically configure managed data disks at node type creation and handle situations where VMs or the virtual machine scale set is reimaged.
 
 > [!IMPORTANT]
-> Service Fabric managed data disk support doesn't initialize NVMe disks on VM SKUs that use NVMe-based storage (for example, v6 and newer SKUs). For these SKUs, initialize and format the managed disk yourself by using a Custom Script Extension.
+> VMSS `_v6` SKU sizes introduce [NVMe disks](/azure/virtual-machines/nvme-overview), which replace the older SCSI-based protocol for disk storage. This change affects disk characteristics and can break existing disk initialization logic for both managed data disks and temporary disks. As a result, required partitions or file systems might not be created, and Service Fabric node bootstrap can stall.
 >
-> If you use the temporary disk for `dataPath` and the VM SKU uses an NVMe temporary disk, you must also initialize and format that disk yourself. For more information, see [Enable NVMe interface on your VMs and VM scale sets (FAQ)](https://learn.microsoft.com/en-us/azure/virtual-machines/enable-nvme-temp-faqs).
+> Service Fabric managed data disk support doesn't initialize NVMe disks automatically. You must initialize and format NVMe disks yourself by using a Custom Script Extension, including when you use the temporary disk for `dataPath`.
+>
+> Although NVMe disks are commonly associated with `_v6` SKUs, some earlier or non-v6 series also use NVMe. For example, [Fxmsv2-series](/azure/virtual-machines/sizes/compute-optimized/fxmsv2-series?tabs=sizebasic#feature-support) uses NVMe-based local storage. Any VM SKU with NVMe disks is subject to the same initialization considerations in this article. For more information, see [Enable NVMe interface on your VMs and VM scale sets (FAQ)](/azure/virtual-machines/enable-nvme-temp-faqs).
+>
+> [Service Fabric managed clusters](/azure/service-fabric/overview-managed-cluster) support NVMe scenarios. If you want a simpler managed experience for NVMe-based SKUs, consider migrating to Service Fabric managed clusters.
 
 ## Prerequisites
 


### PR DESCRIPTION
- Added NVMe guidance to articles/service-fabric/service-fabric-managed-disk.md clarifying that Service Fabric managed data disk support does not initialize NVMe disks on v6 and newer VM SKUs.
- Added explicit guidance that customers must initialize and format those disks themselves by using a Custom Script Extension.
- Added guidance that when dataPath uses a temporary disk and that disk is NVMe-based, customers must also initialize and format it themselves.
- Added a reference to the NVMe temp disk FAQ: https://learn.microsoft.com/en-us/azure/virtual-machines/enable-nvme-temp-faqs.
- Clarify Service Fabric VM extension examples for Windows (ServiceFabricNode, handler 1.1) and Linux (ServiceFabricLinuxNode, handler 2.0), and updated the property table accordingly.