### PR TITLE
Update attach-managed-disk-portal.md

### DIFF
--- a/articles/virtual-machines/windows/attach-managed-disk-portal.md
+++ b/articles/virtual-machines/windows/attach-managed-disk-portal.md
@@ -40,9 +40,9 @@ Follow these steps:
 > [!IMPORTANT]
 > Initialize and format only a newly created, empty data disk. If the disk was previously used or contains existing data, initializing, repartitioning, or formatting it might make the data inaccessible or permanently erase it. Before proceeding, verify the disk number, size, and LUN to ensure that you selected the correct disk.
 >
-> After formatting is complete, confirm that the disk appears as Online and Healthy in Disk Management and that a drive letter has been assigned.
+> After formatting is complete, confirm that the disk appears as **Online** and **Healthy** in **Disk Management** and that it has an assigned drive letter.
 >
-> Avoid assigning the D: drive letter unless required by your application. On many Azure Windows VMs, the D: drive is reserved for temporary storage, and data stored on the temporary disk can be lost during VM redeployment, resizing, or host maintenance.
+> Avoid assigning the `D:` drive letter unless your application requires it. On many Azure Windows VMs, the `D:` drive is reserved for temporary storage, and data stored on the temporary disk might be lost during VM redeployment, resizing, or host maintenance.
 
 Follow these steps:
 

--- a/articles/virtual-machines/windows/attach-managed-disk-portal.md
+++ b/articles/virtual-machines/windows/attach-managed-disk-portal.md
@@ -41,7 +41,6 @@ Follow these steps:
 > Initialize and format only a newly created, empty data disk. If the disk was previously used or contains existing data, initializing, repartitioning, or formatting it might make the data inaccessible or permanently erase it. Before proceeding, verify the disk number, size, and LUN to ensure that you selected the correct disk.
 >
 > After formatting is complete, confirm that the disk appears as **Online** and **Healthy** in **Disk Management** and that it has an assigned drive letter.
->
 > Avoid assigning the `D:` drive letter unless your application requires it. On many Azure Windows VMs, the `D:` drive is reserved for temporary storage, and data stored on the temporary disk might be lost during VM redeployment, resizing, or host maintenance.
 
 Follow these steps:

--- a/articles/virtual-machines/windows/attach-managed-disk-portal.md
+++ b/articles/virtual-machines/windows/attach-managed-disk-portal.md
@@ -41,7 +41,6 @@ Follow these steps:
 > Initialize and format only a newly created, empty data disk. If the disk was previously used or contains existing data, initializing, repartitioning, or formatting it might make the data inaccessible or permanently erase it. Before proceeding, verify the disk number, size, and LUN to ensure that you selected the correct disk.
 >
 > After formatting is complete, confirm that the disk appears as **Online** and **Healthy** in **Disk Management** and that it has an assigned drive letter.
-> Avoid assigning the `D:` drive letter unless your application requires it. On many Azure Windows VMs, the `D:` drive is reserved for temporary storage, and data stored on the temporary disk might be lost during VM redeployment, resizing, or host maintenance.
 
 Follow these steps:
 

--- a/articles/virtual-machines/windows/attach-managed-disk-portal.md
+++ b/articles/virtual-machines/windows/attach-managed-disk-portal.md
@@ -37,6 +37,13 @@ Follow these steps:
 
 ## Initialize a new data disk
 
+> [!IMPORTANT]
+> Initialize and format only a newly created, empty data disk. If the disk was previously used or contains existing data, initializing, repartitioning, or formatting it might make the data inaccessible or permanently erase it. Before proceeding, verify the disk number, size, and LUN to ensure that you selected the correct disk.
+>
+> After formatting is complete, confirm that the disk appears as Online and Healthy in Disk Management and that a drive letter has been assigned.
+>
+> Avoid assigning the D: drive letter unless required by your application. On many Azure Windows VMs, the D: drive is reserved for temporary storage, and data stored on the temporary disk can be lost during VM redeployment, resizing, or host maintenance.
+
 Follow these steps:
 
 1. Connect to the VM.


### PR DESCRIPTION
Added an important caution to verify the correct disk before initialization and formatting, preventing accidental data loss. It also clarifies Azure temporary disk behavior, helping customers avoid storing persistent data on a non-durable drive.

Initialize and format only a newly created, empty data disk. If the disk was previously used or contains existing data, initializing, repartitioning, or formatting it might make the data inaccessible or permanently erase it. Before proceeding, verify the disk number, size, and LUN to ensure that you selected the correct disk.

After formatting is complete, confirm that the disk appears as Online and Healthy in Disk Management and that a drive letter has been assigned.

Avoid assigning the D: drive letter unless required by your application. On many Azure Windows VMs, the D: drive is reserved for temporary storage, and data stored on the temporary disk can be lost during VM redeployment, resizing, or host maintenance.