### PR TITLE
Announce GA for Ephemeral OS Disk full caching

### DIFF
--- a/articles/virtual-machines/ephemeral-os-disks-deploy.md
+++ b/articles/virtual-machines/ephemeral-os-disks-deploy.md
@@ -2,9 +2,10 @@
 title: Deploy Ephemeral OS disks
 description: Learn to deploy ephemeral OS disks for Azure VMs.
 author: Aarthi-Vijayaraghavan
+ai-usage: ai-assisted
 ms.service: azure-virtual-machines
 ms.topic: how-to
-ms.date: 07/23/2020
+ms.date: 09/07/2026
 ms.author: aarthiv
 ms.subservice: disks
 ms.custom: devx-track-azurecli
@@ -16,9 +17,6 @@ ms.custom: devx-track-azurecli
 **Applies to:** :heavy_check_mark: Linux VMs :heavy_check_mark: Windows VMs :heavy_check_mark: Flexible scale sets :heavy_check_mark: Uniform scale sets
 
 This article shows you how to create a virtual machine or virtual machine scale sets with Ephemeral OS disks through Portal, ARM template deployment, CLI and PowerShell.
-
-> [!IMPORTANT]
-> Ephemeral OS disk with full caching is currently in public preview. Preview features are provided without a service level agreement, and aren't recommended for production workloads.
 
 ## Portal
 
@@ -34,16 +32,16 @@ If the option for using an ephemeral disk or OS cache placement or Temp disk pla
 The process to create a scale set that uses an ephemeral OS disk is to add the `diffDiskSettings` property to the
 `Microsoft.Compute/virtualMachineScaleSets/virtualMachineProfile` resource type in the template. Also, the caching policy must be set to `ReadOnly` for the ephemeral OS disk. placement can be changed to `CacheDisk` for OS cache disk placement.
 
-To enable full caching (preview), add `"enableFullCaching": true` to the `diffDiskSettings` section and use API version `2025-04-01` or later.
+To enable full caching, add `"enableFullCaching": true` to the `diffDiskSettings` section and use API version `2025-04-01` or later. Full caching requires a VM size with 8 vCPUs or more. Temp disk and NVMe disk placement are supported on eligible VM sizes that expose the selected local-storage type. Cache disk placement is supported only on GPU VM sizes.
 
 ```json
 {
   "type": "Microsoft.Compute/virtualMachineScaleSets",
   "name": "myScaleSet",
   "location": "East US 2",
-  "apiVersion": "2019-12-01",
+  "apiVersion": "2025-04-01",
   "sku": {
-    "name": "Standard_DS2_v2",
+    "name": "Standard_D8ds_v5",
     "capacity": "2"
   },
   "properties": {
@@ -55,22 +53,23 @@ To enable full caching (preview), add `"enableFullCaching": true` to the `diffDi
         "osDisk": {
           "diffDiskSettings": {
             "option": "Local" ,
-            "placement": "ResourceDisk"
+            "placement": "ResourceDisk",
+            "enableFullCaching": true
           },
           "caching": "ReadOnly",
           "createOption": "FromImage"
         },
         "imageReference":  {
-          "publisher": "publisherName",
-          "offer": "offerName",
-          "sku": "skuName",
-          "version": "imageVersion"
+          "publisher": "Canonical",
+          "offer": "0001-com-ubuntu-server-jammy",
+          "sku": "22_04-lts-gen2",
+          "version": "latest"
         }
       },
       "osProfile": {
         "computerNamePrefix": "myvmss",
         "adminUsername": "azureuser",
-        "adminPassword": "P@ssw0rd!"
+        "adminPassword": "[parameters('adminPassword')]"
       }
     }
   }
@@ -78,12 +77,12 @@ To enable full caching (preview), add `"enableFullCaching": true` to the `diffDi
 ```
 
 > [!NOTE]
-> Replace all the other values accordingly.
+> Define `adminPassword` as a `secureString` parameter in the complete template. Replace the other values as needed.
 
 ## VM template deployment
 You can deploy a VM with an ephemeral OS disk using a template. The process to create a VM that uses ephemeral OS disks is to add the `diffDiskSettings` property to Microsoft.Compute/virtualMachines resource type in the template. Also, the caching policy must be set to `ReadOnly` for the ephemeral OS disk. placement option can be changed to `CacheDisk` for OS cache disk placement.
 
-To enable full caching (preview), add `"enableFullCaching": true` to the `diffDiskSettings` section and use API version `2025-04-01` or later.
+To enable full caching, add `"enableFullCaching": true` to the `diffDiskSettings` section and use API version `2025-04-01` or later.
 
 ```json
 {
@@ -120,9 +119,9 @@ To enable full caching (preview), add `"enableFullCaching": true` to the `diffDi
  }
 ```
 
-### VM template deployment with full caching (preview)
+### VM template deployment with full caching
 
-To deploy a VM with ephemeral OS disk with full caching, use API version `2025-04-01` or later and set `enableFullCaching` to `true` in the `diffDiskSettings` section.
+To deploy a VM with an ephemeral OS disk with full caching, use API version `2025-04-01` or later and set `enableFullCaching` to `true` in the `diffDiskSettings` section. The VM size must have 8 vCPUs or more and local storage greater than (2 &times; OS disk size + 1 GiB).
 
 ```json
 {
@@ -131,37 +130,40 @@ To deploy a VM with ephemeral OS disk with full caching, use API version `2025-0
   "location": "East US 2",
   "apiVersion": "2025-04-01",
   "properties": {
-       "storageProfile": {
-            "osDisk": {
-              "diffDiskSettings": {
-                "option": "Local",
-                "placement": "ResourceDisk",
-                "enableFullCaching": true
-              },
-              "caching": "ReadOnly",
-              "createOption": "FromImage",
-              "managedDisk": {
-                "storageAccountType": "StandardSSD_LRS"
-              }
-            },
-            "imageReference": {
-                "publisher": "MicrosoftWindowsServer",
-                "offer": "WindowsServer",
-                "sku": "2016-Datacenter-smalldisk",
-                "version": "latest"
-            },
-            "hardwareProfile": {
-                 "vmSize": "Standard_DS2_v2"
-             }
+    "hardwareProfile": {
+      "vmSize": "Standard_D8ds_v5"
+    },
+    "storageProfile": {
+      "osDisk": {
+        "diffDiskSettings": {
+          "option": "Local",
+          "placement": "ResourceDisk",
+          "enableFullCaching": true
+        },
+        "caching": "ReadOnly",
+        "createOption": "FromImage",
+        "managedDisk": {
+          "storageAccountType": "StandardSSD_LRS"
+        }
       },
-      "osProfile": {
-        "computerNamePrefix": "myvirtualmachine",
-        "adminUsername": "azureuser",
-        "adminPassword": "P@ssw0rd!"
+      "imageReference": {
+        "publisher": "MicrosoftWindowsServer",
+        "offer": "WindowsServer",
+        "sku": "2016-Datacenter-smalldisk",
+        "version": "latest"
       }
+    },
+    "osProfile": {
+      "computerName": "myvirtualmachine",
+      "adminUsername": "azureuser",
+      "adminPassword": "[parameters('adminPassword')]"
     }
- }
+  }
+}
 ```
+
+> [!NOTE]
+> Define `adminPassword` as a `secureString` parameter in the complete template. The example shows the properties relevant to full caching; add the required network configuration before deployment.
 
 ## CLI
 

--- a/articles/virtual-machines/ephemeral-os-disks-faq.md
+++ b/articles/virtual-machines/ephemeral-os-disks-faq.md
@@ -2,9 +2,10 @@
 title: FAQ Ephemeral OS disks
 description: Frequently asked questions on ephemeral OS disks for Azure VMs.
 author: Aarthi-Vijayaraghavan
+ai-usage: ai-assisted
 ms.service: azure-virtual-machines
 ms.topic: how-to
-ms.date: 05/26/2022
+ms.date: 09/07/2026
 ms.author: aarthiv
 ms.subservice: disks
 # Customer intent: As a cloud architect, I want to understand the limitations and requirements of using ephemeral OS disks for Azure VMs, so that I can effectively plan and deploy virtual machines with optimal storage configurability and resource management.
@@ -133,13 +134,13 @@ A: No, you can't have a mix of ephemeral and persistent OS disk instances within
 
 A: Yes, you can create VMs with Ephemeral OS Disk using REST, Templates, PowerShell, and CLI.
 
-**Q: What is ephemeral OS disk with full caching?**
+**Q: What is Ephemeral OS Disk with full caching?**
 
-A: Ephemeral OS disk with full caching (preview) enhances the standard Ephemeral OS Disk by fully caching the OS disk onto the local disk. This removes the dependency on remote storage in steady state, improving resilience during remote storage outages. With partial caching (the default mode), writes go to a diff disk on local storage and reads for original files come from a remote base disk. With full caching, the entire OS disk is cached locally, eliminating remote read/write latency.
+A: Ephemeral OS Disk with full caching stores the complete OS disk on local VM storage. With partial caching, which is the default, writes go to a local diff disk while reads for unchanged files can use the remote base disk. With full caching, Azure copies the base disk to local storage in the background after the VM starts. After caching completes, OS disk reads and writes are served locally in steady state. This design provides consistent local OS disk performance and improves resilience during remote storage disruptions.
 
-**Q: What are the prerequisites for full caching?**
+**Q: What are the requirements for full caching?**
 
-A: The local disk size of the VM SKU must be greater than (2 &times; OS disk size + 1 GiB). The API version must be `2025-04-01` or later. Full caching is currently supported on all VM SKUs except 2/4-core VMs. For more details, see [Ephemeral OS disks](ephemeral-os-disks.md#full-caching-mode-for-ephemeral-os-disks-preview).
+A: Full caching is designed for stateless workloads and requires a VM size with 8 vCPUs or more. Temp disk (`ResourceDisk`) and NVMe disk (`NvmeDisk`) placement are supported on eligible VM sizes that expose the selected local-storage type. Cache disk (`CacheDisk`) placement is supported only on GPU VM sizes. The selected VM size must have local storage greater than (2 &times; OS disk size + 1 GiB). Use API version `2025-04-01` or later. For more details, see [Ephemeral OS disks](ephemeral-os-disks.md#full-caching-mode-for-ephemeral-os-disks).
 
 **Q: Is there any additional cost for full caching?**
 
@@ -151,4 +152,4 @@ A: The OS disk is cached in the background after the VM boots up, so there's no 
 
 **Q: What is the current availability status of full caching?**
 
-A: Ephemeral OS disk with full caching is currently in public preview.
+A: Ephemeral OS Disk with full caching is generally available on VM sizes with 8 vCPUs or more. Temp disk and NVMe disk placement are supported on eligible VM sizes that expose the selected local-storage type. Cache disk placement is supported only on GPU VM sizes.

--- a/articles/virtual-machines/ephemeral-os-disks.md
+++ b/articles/virtual-machines/ephemeral-os-disks.md
@@ -2,10 +2,11 @@
 title: Ephemeral OS disks
 description: Learn more about ephemeral OS disks for Azure VMs.
 author: viveksingla08
+ai-usage: ai-assisted
 ms.service: azure-virtual-machines
 ms.custom:
 ms.topic: how-to
-ms.date: 07/23/2020
+ms.date: 09/07/2026
 ms.author: viveksingla
 ms.subservice: disks
 # Customer intent: As a cloud engineer, I want to implement ephemeral OS disks for Azure VMs, so that I can achieve lower latency and faster reimaging for stateless applications while optimizing storage costs and performance.
@@ -20,10 +21,7 @@ Ephemeral OS disks are created on the local virtual machine (VM) storage and not
 Ephemeral OS Disk is available in two caching modes:
 
 - **Partial caching (Default)**: Partial caching splits the OS disk between a diff disk on local storage and a base disk in managed disks. All writes occur on the diff disk, while the base disk serves read operations for original files. Optimized for cloud-native and stateless applications, partial ephemeral OS disk balances performance with efficiency. All existing ephemeral VMs are created in partial caching mode.
-- **Full caching (Preview)**: Full caching caches the entire OS disk on local storage, completely removing dependency on remote storage in steady state. Ideal for IO-sensitive stateless workloads, full caching enhances both performance and reliability by eliminating remote read/write latency. Workloads such as quorum-based databases, data analytics, and real-time processing benefit from this feature. However, full caching requires 2x the OS disk space on local storage to store the complete image locally.
-
-> [!IMPORTANT]
-> Ephemeral OS disk with full caching is currently in public preview. Preview features are provided without a service level agreement, and aren't recommended for production workloads.
+- **Full caching**: Full caching stores the complete OS disk on local VM storage. After background caching completes, OS disk I/O is served from local storage, removing the dependency on remote storage in steady state. Full caching is designed for I/O-sensitive stateless workloads and requires more local storage than partial caching.
 
 The key features of ephemeral disks are:
 
@@ -34,7 +32,7 @@ The key features of ephemeral disks are:
 - Offers lower latency, similar to a temporary disk.
 - Supports Premium SSD & Standard SSD for higher SLA.
 - Supported in all Azure regions.
-- Supports full caching mode (preview) for enhanced performance and reliability during remote storage outages.
+- Supports full caching mode for consistent local OS disk performance and improved resilience during remote storage disruptions.
 
 Key differences between persistent and ephemeral OS disks:
 
@@ -71,7 +69,7 @@ Ephemeral OS Disk utilizes local storage within the VM. Since different VMs have
 You can choose to deploy Ephemeral OS Disk on NVMe disk, temp disk, or cache on the VM.
 The image OS disk’s size should be less than or equal to the NVMe/temp/cache size of the VM size chosen.
 
-For **full caching mode (preview)**, the local disk size of the VM SKU must be greater than (2 &times; OS disk size + 1 GiB). The temporary disk is reduced by 2&times; the OS disk size, and that space is used to store the fully cached OS disk. The OS disk is cached in the background after the VM boots up.
+For **full caching mode**, the local disk size of the VM SKU must be greater than (2 &times; OS disk size + 1 GiB). The temporary disk is reduced by 2&times; the OS disk size, and that space is used to store the fully cached OS disk. The OS disk is cached in the background after the VM boots up.
 
 For **OS cache placement**: Standard Windows Server images from the marketplace are about 127 GiB, which means that you need a VM size that has a cache equal to or larger than 127 GiB. The Standard_DS3_v2 has a cache size of 127 GiB, which is large enough. In this case, the Standard_DS3_v2 is the smallest size in the DSv2 series that you can use with this image.
 
@@ -85,7 +83,7 @@ For **NVMe disk placement (GA)**: Standard Ubuntu server image from marketplace 
 > 
 > If opting for NVMe disk placement (GA), Final NVMe Disk size = (Total no. of NVMe disks - NVMe Disks used for OS) * Size of each NVMe disk. Where NVMe Disks used for OS is the minimum number of disks required for OS disk depending on the size of OS disk and the size of each NVMe disk.
 >
-> If opting for full caching mode (preview), Final Temp disk size = (Initial temp disk size - 2 &times; OS image size). The local disk must have at least (2 &times; OS disk size + 1 GiB) available.
+> If opting for full caching mode, Final Temp disk size = (Initial temp disk size - 2 &times; OS image size). The local disk must have at least (2 &times; OS disk size + 1 GiB) available.
 
 If Ephemeral OS disk is using **Temp Disk Placement**, it shares the IOPS(input/output operations per second) with temp disk. If Ephemeral OS disk is using **NVMe Disk Placement**, it provides the IOPS(input/output operations per second) of NVMe disks being used.
 
@@ -142,14 +140,18 @@ You can choose to use customer managed keys or platform managed keys when you en
 >
 For more information on [Encryption at host](./disk-encryption.md)
 
-## Full caching mode for Ephemeral OS disks (preview)
+## Full caching mode for Ephemeral OS disks
 
-Ephemeral OS disk with full caching enhances the standard ephemeral OS disk by fully caching the OS disk onto the local disk. This feature greatly improves the resilience of general-purpose VMs and virtual machine scale sets during remote storage outages. These outages—often caused by extreme weather or power failures—can lead to VM downtime events. This feature mitigates such risks by ensuring the OS disk remains available even during storage disruptions.
+Ephemeral OS disk with full caching stores the complete OS disk on local VM storage. With partial caching, writes are stored on the local diff disk while reads for unchanged files can still use the remote base disk. With full caching, Azure copies the base disk to local storage in the background after the VM starts. After caching completes, OS disk reads and writes are served locally in steady state.
+
+Full caching is intended for I/O-sensitive stateless workloads on Azure virtual machines and Virtual Machine Scale Sets. Example workloads include data analytics, real-time processing, quorum-based databases, and large-scale stateless services.
 
 When a VM is created with full caching enabled:
 
-- The temporary disk is reduced by 2&times; the OS disk size, and that space is used to create the OS disk.
-- The OS disk is cached in the background after the VM boots up. This caching process ensures no impact on VM creation times.
+- Azure reserves local storage equal to twice the configured OS disk size.
+- The available local temporary storage is reduced by the reserved amount.
+- The VM can start while Azure caches the OS disk in the background.
+- After caching completes, OS disk I/O no longer depends on the remote base disk in steady state.
 
 ### Prerequisites for full caching
 
@@ -158,14 +160,15 @@ When a VM is created with full caching enabled:
 | OS disk must be stateless | Full caching is designed for stateless workloads |
 | VM SKU eligibility | Local disk size must be greater than (2 &times; OS disk size + 1 GiB) |
 | API version | `2025-04-01` or later |
-| Supported VM sizes | All VM SKUs except 2/4-core VMs (preview) |
+| Supported VM sizes | VM sizes with 8 vCPUs or more |
+| Supported placement | Temp disk (`ResourceDisk`) and NVMe disk (`NvmeDisk`) placement are supported on eligible VM sizes that expose the selected local-storage type. Cache disk (`CacheDisk`) placement is supported only on GPU VM sizes. |
 
 ### How to enable full caching
 
 To enable full caching, set the `enableFullCaching` property to `true` in the `diffDiskSettings` section of your deployment template or REST API call. See [Deploy Ephemeral OS disks](ephemeral-os-disks-deploy.md) for detailed deployment instructions.
 
 > [!NOTE]
-> Full caching mode is currently in public preview. Support for 2/4-core VMs is planned for a future release. No extra cost is charged for full caching beyond the standard VM and disk costs.
+> No extra cost is charged for full caching beyond the standard VM and disk costs.
 
 ## SSD storage account support for Ephemeral OS disks
 


### PR DESCRIPTION
## Summary
- remove public preview labels and disclaimers for Ephemeral OS Disk full caching
- document the GA support matrix for VM size and local-disk placement
- update VM and VMSS deployment examples to use the full-caching property, a supported 8-vCPU SKU, and secure password parameters
- align the FAQ with GA behavior and requirements

## Validation
- `git diff --check`
- parsed all JSON deployment examples with `ConvertFrom-Json`
- verified no full-caching preview or 2/4-core preview wording remains in the three articles
- VS Code diagnostics report no errors in the changed files

## Notes
- focused `markdownlint-cli2` still reports pre-existing legacy style violations across these articles, primarily line-length and table-format rules